### PR TITLE
feat: channel switching bug

### DIFF
--- a/app/src/pages/Home/index.tsx
+++ b/app/src/pages/Home/index.tsx
@@ -169,13 +169,9 @@ export default function Home({ isConfigSet }: { isConfigSet: boolean }) {
     activeChatRef.current = chatToUse;
     getChannelUsers(chatToUse.name);
     getNonInvitedUsers(chatToUse.name);
-
-    setTimeout(() => {
-      updateSelectedActiveChat(chatToUse);
-    }, 500);
-
     setMessagesOffset(20);
     setTotalMessageCount(0);
+    updateSelectedActiveChat(chatToUse);
   }, [app, manageEventSubscription]);
 
   const onDMSelected = useCallback(async (dm?: DMChatInfo, sc?: ActiveChat) => {
@@ -224,7 +220,6 @@ export default function Home({ isConfigSet }: { isConfigSet: boolean }) {
       };
     }
 
-    updateSelectedActiveChat(selectedChat);
     setDmContextId(sc?.contextId || dm?.context_id || "");
     setIsOpenSearchChannel(false);
     setActiveChat(selectedChat);
@@ -234,6 +229,7 @@ export default function Home({ isConfigSet }: { isConfigSet: boolean }) {
     setTotalMessageCount(0);
     setOpenThread(undefined);
     setCurrentOpenThread(undefined);
+    updateSelectedActiveChat(selectedChat);
   }, []);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
# feat: channel switching bug

## Description
From DM to channel would go into switching loop because of dependency of refresh needed to active websocket

after & before - dont mind double markdown icons -> react quill has issue with dev & prod , on prod it hides top one


https://github.com/user-attachments/assets/8aa20656-c360-43eb-ac81-70eaf96d48c6


https://github.com/user-attachments/assets/e4c516a5-1a32-4281-8307-e6ef78131443

