### PR TITLE
fix: web + desktop options

### DIFF
--- a/app/dev-dist/sw.js
+++ b/app/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-c6a197bf'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.5ncbhslc1bc"
+    "revision": "0.gk6gm23pm7g"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -50,9 +50,15 @@ function App() {
       // If node_url query param is present, redirect to auth (login) page
       const nodeUrlFromQuery = getNodeUrlFromUrl();
       if (nodeUrlFromQuery) {
+        // Remove node_url from both query string and hash
         const url = new URL(window.location.href);
         url.searchParams.delete("node_url");
         url.searchParams.delete("node-url");
+        const hashParams = new URLSearchParams(url.hash.slice(1));
+        hashParams.delete("node_url");
+        hashParams.delete("node-url");
+        const remaining = hashParams.toString();
+        url.hash = remaining ? `#${remaining}` : "";
         window.history.replaceState({}, "", url.toString());
         if (location.pathname !== "/login") {
           navigate("/login", { replace: true });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -38,11 +38,18 @@ function App() {
     // Only check config once to avoid repeated auth checks
     if (hasInitializedRef.current) return;
 
+    // Set node URL from query/hash params IMMEDIATELY (before CalimeroProvider's
+    // processHashParams fires) so that getAppEndpointKey() is non-empty when it runs.
+    // CalimeroProvider skips setting isAuthenticated if appEndpointKey is empty.
+    const nodeUrlEarly = getNodeUrlFromUrl();
+    if (nodeUrlEarly) {
+      setAppEndpointKey(nodeUrlEarly.trim());
+    }
+
     const timer = setTimeout(() => {
-      // If node_url query param is present, set it and redirect to auth (login) page
+      // If node_url query param is present, redirect to auth (login) page
       const nodeUrlFromQuery = getNodeUrlFromUrl();
       if (nodeUrlFromQuery) {
-        setAppEndpointKey(nodeUrlFromQuery.trim());
         const url = new URL(window.location.href);
         url.searchParams.delete("node_url");
         url.searchParams.delete("node-url");

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -3,13 +3,28 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { BrowserRouter } from "react-router-dom";
-import { AppMode, CalimeroProvider } from "@calimero-network/calimero-client";
+import { AppMode, CalimeroProvider, setAppEndpointKey, setAccessToken, setRefreshToken } from "@calimero-network/calimero-client";
 import { ToastProvider } from "@calimero-network/mero-ui";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
 import { WebSocketProvider } from "./contexts/WebSocketContext.tsx";
 import { log } from "./utils/logger.ts";
 
 import 'react-photo-view/dist/react-photo-view.css';
+
+// Pre-process Tauri SSO hash params BEFORE React mounts.
+// CalimeroProvider reads localStorage on init, so tokens must be there
+// before the first render — not in a useEffect which is always too late.
+(function bootstrapHashParams() {
+  const hash = window.location.hash.slice(1);
+  if (!hash) return;
+  const p = new URLSearchParams(hash);
+  const nodeUrl    = p.get("node_url");
+  const accessToken  = p.get("access_token");
+  const refreshToken = p.get("refresh_token");
+  if (nodeUrl)      setAppEndpointKey(nodeUrl.trim());
+  if (accessToken)  setAccessToken(accessToken);
+  if (refreshToken) setRefreshToken(refreshToken);
+})();
 
 // Register service worker for PWA
 if ("serviceWorker" in navigator) {

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -18,12 +18,21 @@ import 'react-photo-view/dist/react-photo-view.css';
   const hash = window.location.hash.slice(1);
   if (!hash) return;
   const p = new URLSearchParams(hash);
-  const nodeUrl    = p.get("node_url");
+  const nodeUrl     = p.get("node_url");
   const accessToken  = p.get("access_token");
   const refreshToken = p.get("refresh_token");
   if (nodeUrl)      setAppEndpointKey(nodeUrl.trim());
   if (accessToken)  setAccessToken(accessToken);
   if (refreshToken) setRefreshToken(refreshToken);
+  // Strip auth tokens from URL immediately so they don't linger in
+  // the address bar, browser history, or get picked up by other scripts.
+  if (accessToken || refreshToken) {
+    p.delete("access_token");
+    p.delete("refresh_token");
+    p.delete("expires_in");
+    const remaining = p.toString();
+    window.history.replaceState(null, "", remaining ? `#${remaining}` : window.location.pathname + window.location.search);
+  }
 })();
 
 // Register service worker for PWA

--- a/app/src/pages/Login/LandingPage.tsx
+++ b/app/src/pages/Login/LandingPage.tsx
@@ -272,9 +272,42 @@ const TerminalText = styled.div`
   }
 `;
 
+// ─── Use on Web Button ──────────────────────────────────────────────────────────
+
+const UseOnWebButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(165,255,17,0.1);
+  border: 1px solid rgba(165,255,17,0.35);
+  border-radius: 100px;
+  padding: 11px 24px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #a5ff11;
+  cursor: pointer;
+  margin-top: 1.25rem;
+  animation: ${fadeUp} 0.6s 0.5s ease both;
+  transition: background 0.2s, border-color 0.2s, transform 0.15s;
+
+  &:hover {
+    background: rgba(165,255,17,0.18);
+    border-color: rgba(165,255,17,0.6);
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+`;
+
 // ─── Component ─────────────────────────────────────────────────────────────────
 
-export default function LandingPage() {
+interface LandingPageProps {
+  onUseOnWeb?: () => void;
+}
+
+export default function LandingPage({ onUseOnWeb }: LandingPageProps) {
   return (
     <Page>
       {/* Background layers */}
@@ -342,6 +375,16 @@ export default function LandingPage() {
             <span className="cursor" />
           </TerminalText>
         </TerminalBox>
+
+        {onUseOnWeb && (
+          <UseOnWebButton onClick={onUseOnWeb}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+            </svg>
+            Use on Web
+          </UseOnWebButton>
+        )}
       </Content>
     </Page>
   );

--- a/app/src/pages/Login/index.tsx
+++ b/app/src/pages/Login/index.tsx
@@ -1,7 +1,8 @@
-import { useCalimero } from "@calimero-network/calimero-client";
+import React from "react";
+import { useCalimero, apiClient, setAppEndpointKey } from "@calimero-network/calimero-client";
 import { styled } from "styled-components";
 import TabbedInterface from "../../components/contextOperations/TabbedInterface";
-import { Button } from "@calimero-network/mero-ui";
+import { Button, Input } from "@calimero-network/mero-ui";
 import {
   clearStoredSession,
   clearSessionActivity,
@@ -11,6 +12,7 @@ import { getInvitationFromStorage } from "../../utils/invitation";
 import InvitationHandlerPopup from "../../components/popups/InvitationHandlerPopup";
 import CreateWorkspacePopup from "../../components/popups/CreateWorkspacePopup";
 import LandingPage from "./LandingPage";
+import { getApplicationId, getApplicationPath } from "../../constants/config";
 
 declare global {
   interface Window {
@@ -114,6 +116,36 @@ const CreateWorkspaceButton = styled.div`
   border-top: 1px solid rgba(255, 255, 255, 0.06);
 `;
 
+const NodeConnectForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+`;
+
+
+const NodeConnectLabel = styled.label`
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: #b8b8d1;
+`;
+
+const ConnectBackLink = styled.button`
+  background: none;
+  border: none;
+  color: rgba(255,255,255,0.35);
+  font-size: 0.78rem;
+  cursor: pointer;
+  text-align: center;
+  padding: 0;
+  margin-top: 0.25rem;
+  transition: color 0.15s;
+
+  &:hover {
+    color: rgba(255,255,255,0.6);
+  }
+`;
+
 interface LoginProps {
   isAuthenticated: boolean;
   isConfigSet: boolean;
@@ -125,6 +157,10 @@ export default function Login({ isAuthenticated, isConfigSet }: LoginProps) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [loggedOut, setLoggedOut] = useState(false);
   const [showCreateWorkspace, setShowCreateWorkspace] = useState(false);
+  const [showWebFlow, setShowWebFlow] = useState(false);
+  const [nodeUrl, setNodeUrl] = useState("");
+  const [connectError, setConnectError] = useState("");
+  const [connecting, setConnecting] = useState(false);
 
   const tabs = [{ id: "chat", label: "Chat" }];
 
@@ -167,12 +203,106 @@ export default function Login({ isAuthenticated, isConfigSet }: LoginProps) {
     setRefreshKey((prev) => prev + 1);
   };
 
+  const handleUseOnWeb = async () => {
+    if (window.__TAURI_INVOKE__) {
+      // In Tauri: open the app URL in default browser (strip hash to avoid passing SSO tokens)
+      const webUrl = window.location.href.split("#")[0];
+      try {
+        await window.__TAURI_INVOKE__("open_url_in_browser", { url: webUrl });
+      } catch {
+        // Fallback if command fails
+        window.open(webUrl, "_blank");
+      }
+    } else {
+      // In browser: show node connection form
+      setShowWebFlow(true);
+    }
+  };
+
+  const handleConnect = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const url = nodeUrl.trim().replace(/\/$/, "");
+    if (!url) {
+      setConnectError("Please enter your node URL.");
+      return;
+    }
+    try {
+      new URL(url);
+    } catch {
+      setConnectError("That doesn't look like a valid URL.");
+      return;
+    }
+    setConnecting(true);
+    setConnectError("");
+    try {
+      const res = await fetch(`${url}/auth/health`, { signal: AbortSignal.timeout(5000) });
+      if (!res.ok) throw new Error();
+    } catch {
+      setConnecting(false);
+      setConnectError("Node not reachable. Make sure it's running and the URL is correct.");
+      return;
+    }
+    setAppEndpointKey(url);
+    const callbackUrl = window.location.href.split("#")[0];
+    try {
+      await apiClient.auth().login({
+        url,
+        callbackUrl,
+        permissions: [],
+        mode: 'multi-context',
+        applicationId: getApplicationId(),
+        applicationPath: getApplicationPath(),
+      });
+      // login() sets window.location.href — page is navigating, nothing to do here
+    } catch {
+      setConnecting(false);
+      setConnectError("Failed to reach auth service. Please try again.");
+    }
+  };
+
   if (loggedOut) {
-    return <LandingPage />;
+    return <LandingPage onUseOnWeb={handleUseOnWeb} />;
   }
 
   if (!isAuthenticated && !isConfigSet) {
-    return <LandingPage />;
+    if (showWebFlow) {
+      return (
+        <Wrapper>
+          <Card>
+            <Title>Connect to your node</Title>
+            <Subtitle>
+              Enter the URL of your Calimero node to continue.
+            </Subtitle>
+            <NodeConnectForm onSubmit={handleConnect}>
+              <div style={{ display: "flex", flexDirection: "column", gap: "0.3rem" }}>
+                <NodeConnectLabel htmlFor="nodeUrl">Node URL</NodeConnectLabel>
+                <Input
+                  id="nodeUrl"
+                  type="text"
+                  placeholder="https://node.example.com"
+                  value={nodeUrl}
+                  onChange={(e) => { setNodeUrl(e.target.value); setConnectError(""); }}
+                  disabled={connecting}
+                  autoFocus
+                />
+              </div>
+              {connectError && (
+                <div style={{ fontSize: "0.72rem", color: "#e74c3c", textAlign: "center", lineHeight: 1.5 }}>
+                  {connectError}
+                </div>
+              )}
+              <Button type="submit" disabled={connecting || !nodeUrl.trim()}>
+                {connecting ? "Checking node…" : "Continue"}
+              </Button>
+              <ConnectBackLink type="button" onClick={() => { setShowWebFlow(false); setConnectError(""); }}>
+                ← Back
+              </ConnectBackLink>
+            </NodeConnectForm>
+          </Card>
+        </Wrapper>
+      );
+    }
+    return <LandingPage onUseOnWeb={handleUseOnWeb} />;
   }
 
   return (


### PR DESCRIPTION
## Description
Frontend now supports both web and desktop. On desktop it uses auth skip and automatically redirected to context / group page.
On web it has enter node url and goes through auth process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication bootstrapping and URL/token handling (timing-sensitive and security-adjacent), plus introduces a new node-connect/login redirect path that can affect login flow behavior.
> 
> **Overview**
> Adds a **web-first connect flow**: the login landing now offers a “Use on Web” path that prompts for a node URL, validates node reachability via `/auth/health`, then triggers `apiClient.auth().login()` with `applicationId`/`applicationPath`.
> 
> Improves **desktop/Tauri SSO bootstrap** by pre-processing `#access_token`/`#refresh_token`/`#node_url` *before* React mounts (ensuring `CalimeroProvider` sees tokens on init) and stripping tokens from the URL/history; `App.tsx` also sets `appEndpointKey` earlier and now removes `node_url` from both query and hash before redirecting to `/login`.
> 
> Includes a small service-worker precache revision bump for `index.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 875d94ee22e45a1a1c6ebcdd35d715ec64f546e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->