### PR TITLE
feat: bump node rc39

### DIFF
--- a/logic/Cargo.lock
+++ b/logic/Cargo.lock
@@ -142,9 +142,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "calimero-prelude"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "315700f150897b887fad29d815b57965d46330858085af310d049f5316554bb6"
+checksum = "01a49e7b580a87c233249875512586c4fed9da058c94c8b5160739987a2f122e"
 dependencies = [
  "borsh 1.6.0",
  "calimero-primitives",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "calimero-primitives"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cb46fc3473ce496c9f04e508e2adfe986322d4ad3801e5a7dcd09113718294"
+checksum = "f77df4b7437466f466e00d88d33d4e507a86d3c0c5ff04ae97359a357e5ab2d0"
 dependencies = [
  "borsh 1.6.0",
  "bs58",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "calimero-sdk"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765002fc9583eef4d9e1891379d57ae2bdc4d5a96fe89e5833b0d579b0928d80"
+checksum = "25d6e5ddcbeece44372dcdb609de42d74854c207aa7aa64b06e7c2d55330d931"
 dependencies = [
  "borsh 1.6.0",
  "calimero-prelude",
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "calimero-sdk-macros"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faa9aca11b6ce8b4bfbbce58343914b4d7db25d4854ba45ee7e174cc8d93494"
+checksum = "001a94cc2a0176ae0d57146ce039a6510b624cff0d93b7a673dfee49d223e165"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "calimero-storage"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d4e2134416ba2ae386243a01f52d901f559eda44f341c8f1c777bd22ac4d61"
+checksum = "7281f848e687e3c922a886951a370b744a48e43548aa7bc418532eaa2550c28f"
 dependencies = [
  "borsh 1.6.0",
  "calimero-prelude",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "calimero-storage-macros"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f998610163c5bd139e8db7e0db6b4e4b9704e3e00aca9f860b6a06344a3a1a"
+checksum = "793fe897ebc2e01753fba26684cef44a4db29003653b50a1993350c92c1646fe"
 dependencies = [
  "quote",
  "syn 2.0.116",
@@ -237,18 +237,18 @@ dependencies = [
 
 [[package]]
 name = "calimero-sys"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132f5faa57aca0be376367da54cf6e2eb8dc6449abc49226d916e858473617d6"
+checksum = "d19697728179592cf21ce485e60ad0495423b1cc9fd47c080b58e8d214926dcf"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "calimero-wasm-abi"
-version = "0.10.1-rc.38"
+version = "0.10.1-rc.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afca25e598071e1a9a48343ff350ecdfc08754feeea25726fec8a5db54608b47"
+checksum = "a36d59171bcddd9e36003b9c7f8f70358082a00d5b5defc8475ea241100dd8ea"
 dependencies = [
  "proc-macro2",
  "serde",

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -1,6 +1,6 @@
 # TODO BEFORE MERGE: revert calimero-sdk/storage/wasm-abi to "edge" (or the
 # published stable tag) instead of the pinned rc below. The rc pin is here so
-# local builds match the dev merod binary (0.10.1-rc.38). On main these should
+# local builds match the dev merod binary (0.10.1-rc.39). On main these should
 # track the latest published release so CI doesn't break on the next rc bump.
 
 [package]
@@ -17,13 +17,13 @@ base64 = "0.22.1"
 borsh = "0.10.3"
 borsh-derive = "0.10.3"
 bs58 = "0.5.1"
-calimero-sdk = "0.10.1-rc.38"
-calimero-storage = "0.10.1-rc.38"
-calimero-storage-macros = "0.10.1-rc.38"
+calimero-sdk = "0.10.1-rc.39"
+calimero-storage = "0.10.1-rc.39"
+calimero-storage-macros = "0.10.1-rc.39"
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = "0.10.1-rc.38"
+calimero-wasm-abi = "0.10.1-rc.39"
 serde_json = "1.0.113"
 
 [patch.crates-io]

--- a/workflows/dm.yml
+++ b/workflows/dm.yml
@@ -25,7 +25,7 @@ force_pull_image: true
 nodes:
   chain_id: testnet-1
   count: 2
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.38
+  image: ghcr.io/calimero-network/merod:0.10.1-rc.39
   prefix: calimero-node
 
 steps:

--- a/workflows/e2e-v2.yml
+++ b/workflows/e2e-v2.yml
@@ -21,7 +21,7 @@ force_pull_image: true
 nodes:
   chain_id: testnet-1
   count: 2
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.38
+  image: ghcr.io/calimero-network/merod:0.10.1-rc.39
   prefix: calimero-node
 
 steps:

--- a/workflows/e2e.yml
+++ b/workflows/e2e.yml
@@ -8,13 +8,13 @@ description: >
 force_pull_image: true
 
 # TODO BEFORE MERGE: change image tag back to :edge (or latest stable release)
-# — rc.38 is pinned here to match the local dev binary. All workflow files
+# — rc.39 is pinned here to match the local dev binary. All workflow files
 # (dm.yml, governance.yml, integration-setup.yml, non-admin-creates.yml,
 # e2e-v2.yml) need the same change, plus logic/Cargo.toml calimero-sdk deps.
 nodes:
   chain_id: testnet-1
   count: 3
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.38
+  image: ghcr.io/calimero-network/merod:0.10.1-rc.39
   prefix: calimero-node
 
 steps:

--- a/workflows/integration-setup.yml
+++ b/workflows/integration-setup.yml
@@ -16,7 +16,7 @@ wait_timeout: 120
 nodes:
   chain_id: testnet-1
   count: 2
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.38
+  image: ghcr.io/calimero-network/merod:0.10.1-rc.39
   prefix: calimero-node
 
 steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades the `merod` node image and multiple `calimero-*` crate versions, which can introduce subtle compatibility or behavior changes in builds and end-to-end workflows.
> 
> **Overview**
> Updates the project to target Calimero `0.10.1-rc.39` by bumping `calimero-sdk`/`calimero-storage`/`calimero-wasm-abi` dependencies (and `Cargo.lock` entries) and retagging all referenced `merod` workflow node images from `0.10.1-rc.38` to `0.10.1-rc.39`.
> 
> Also adjusts pinned-version comments to reflect the new rc tag so local builds and CI workflows remain aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ffc719d7ee6d001ebb95e62b8fd2a55b9558436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->