### PR TITLE
ci: add AI code review and doc auto-update workflows

### DIFF
--- a/.ai-reviewer.yaml
+++ b/.ai-reviewer.yaml
@@ -1,0 +1,16 @@
+version: 1
+
+anthropic:
+  default_model: claude-sonnet-4-6
+  enable_prompt_caching: true
+
+doc_generation:
+  enabled: true
+  model: claude-haiku-4-5-20251001
+  max_files: 10
+  static_docs_dirs:
+    - docs/
+  pr_labels:
+    - automated-docs
+    - documentation
+  pr_draft: true

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -1,0 +1,79 @@
+name: AI Code Review
+
+on:
+  pull_request:
+    # `synchronize` omitted — review fires on PR open/reopen/draft→ready, not each push.
+    # Re-trigger via toggling draft or workflow_dispatch.
+    types: [opened, reopened, ready_for_review]
+    # Pure-doc PRs are owned by Doc Auto-Update; skip to avoid paying twice.
+    paths-ignore:
+      - 'docs/**'
+      - 'architecture/**'
+      - 'docs-static/**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
+      agents:
+        description: "Number of agents (1-5)"
+        required: false
+        default: "3"
+        type: choice
+        options: ["1", "2", "3", "4", "5"]
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # Skip on draft PRs and fork PRs (forks don't get repo secrets).
+    # Maintainers can review fork PRs manually via workflow_dispatch.
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Pinned SHA — bump deliberately when adopting new reviewer features.
+      - name: Install ai-code-reviewer
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@713c5b1251132dd93b6ec70889e336dad3c09402
+
+      - name: Determine PR number and agent count
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "agents=${{ github.event.inputs.agents }}"    >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+            # Default to 1 agent for cost; bump via workflow_dispatch when needed.
+            echo "agents=1"                                        >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run AI Code Review
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          ai-reviewer review-pr \
+            ${{ github.repository }} \
+            ${{ steps.pr.outputs.number }} \
+            --agents ${{ steps.pr.outputs.agents }} \
+            --reviewer-name "MeroReviewer" \
+            --output github

--- a/.github/workflows/doc-update.yaml
+++ b/.github/workflows/doc-update.yaml
@@ -1,0 +1,82 @@
+name: Doc Auto-Update
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to generate docs for (leave blank to auto-detect)"
+        type: string
+        required: false
+      dry_run:
+        description: "Dry run: print changes without opening a PR"
+        type: boolean
+        default: false
+
+concurrency:
+  group: doc-update-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Pinned SHA — bump deliberately when adopting new reviewer features.
+      - name: Install ai-code-reviewer
+        run: pip install git+https://github.com/calimero-network/ai-code-reviewer.git@713c5b1251132dd93b6ec70889e336dad3c09402
+
+      - name: Get merged PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          PR_NUM=""
+          if [[ "$INPUT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            PR_NUM="$INPUT_PR_NUMBER"
+          fi
+
+          if [ -z "$PR_NUM" ]; then
+            if ! PR_NUM=$(gh api "/repos/$REPO/commits/$SHA/pulls" --jq '.[0].number // empty'); then
+              echo "::warning::gh api commits/{sha}/pulls failed; doc update will be skipped"
+              PR_NUM=""
+            fi
+          fi
+
+          if [[ ! "$PR_NUM" =~ ^[0-9]+$ ]]; then
+            PR_NUM=""
+          fi
+
+          echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
+
+      - name: Generate and open doc update PR
+        if: steps.pr.outputs.number != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          DRY_RUN_FLAG=()
+          if [ "$DRY_RUN" = "true" ]; then
+            DRY_RUN_FLAG=(--dry-run)
+          fi
+          ai-reviewer update-docs "$REPO" "$PR_NUMBER" "${DRY_RUN_FLAG[@]}"
+
+      - name: No PR detected
+        if: steps.pr.outputs.number == ''
+        run: echo "Could not detect a merged PR — skipping doc update."

--- a/app/dev-dist/sw.js
+++ b/app/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-c6a197bf'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.ps75abueup4"
+    "revision": "0.kl00mn73prs"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/app/package.json
+++ b/app/package.json
@@ -43,6 +43,7 @@
     "bootstrap-icons": "^1.13.1",
     "bs58": "^6.0.0",
     "dompurify": "^3.3.0",
+    "fflate": "^0.8.3",
     "iframe-resizer-react": "^5.1.5",
     "install": "^0.13.0",
     "lodash": "^4.17.23",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       dompurify:
         specifier: ^3.3.0
         version: 3.3.0
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       iframe-resizer-react:
         specifier: ^5.1.5
         version: 5.1.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2535,6 +2538,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -6692,6 +6698,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/app/src/utils/invitation.ts
+++ b/app/src/utils/invitation.ts
@@ -1,4 +1,5 @@
 import bs58 from "bs58";
+import { deflateSync, inflateSync } from "fflate";
 import type { SignedGroupOpenInvitation } from "../api/groupApi";
 
 /**
@@ -102,9 +103,11 @@ export function parseGroupInvitationPayload(
 
 const BASE58_ALPHABET = /^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+$/;
 
-/** Base58 encode a JSON payload string. Compact and copy-friendly (no +/= chars). */
+/** Compress + base58 encode a JSON payload string. Shorter URLs than plain base58. */
 export function encodeInvitationPayload(payload: string): string {
-  return bs58.encode(new TextEncoder().encode(payload));
+  const bytes = new TextEncoder().encode(payload);
+  const compressed = deflateSync(bytes, { level: 9 });
+  return bs58.encode(compressed);
 }
 
 /**
@@ -116,10 +119,16 @@ export function decodeInvitationPayload(encoded: string): string | null {
   if (!encoded || typeof encoded !== "string") return null;
   const trimmed = encoded.trim();
 
-  // Try base58
+  // Try base58 (new: compressed; old: raw UTF-8)
   if (BASE58_ALPHABET.test(trimmed)) {
     try {
-      return new TextDecoder().decode(bs58.decode(trimmed));
+      const bytes = bs58.decode(trimmed);
+      try {
+        return new TextDecoder().decode(inflateSync(bytes));
+      } catch {
+        // Not compressed — old invitation format
+        return new TextDecoder().decode(bytes);
+      }
     } catch {
       // fall through
     }


### PR DESCRIPTION
Adds MeroReviewer AI code review and doc auto-update workflows.

- Pins ai-code-reviewer to SHA `713c5b1` for security
- Skips doc-only PRs to avoid double review cost
- Fork PRs excluded (no repo secrets)
- Defaults to 1 review agent (cost control)
- Doc auto-update opens draft PRs on merge to main/master

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GitHub Actions that run with repo secrets and can open/update PRs, so misconfiguration could impact CI cost or permissions. Invitation link encoding changes may break join flows if any decoder edge cases slip through, though legacy formats are still supported.
> 
> **Overview**
> **Adds AI automation in CI.** Introduces `.ai-reviewer.yaml` plus two GitHub Actions workflows: `AI Code Review` (runs on PR open/reopen/ready, skips doc-only changes and fork PRs, supports manual dispatch with configurable agent count) and `Doc Auto-Update` (on push to `main`/`master` or manual dispatch, detects the merged PR and opens a docs update PR via `ai-reviewer update-docs`), both installing `ai-code-reviewer` from a pinned commit.
> 
> **Shortens invite URLs.** Updates invitation encoding to `deflate`-compress JSON before base58 encoding (via new `fflate` dependency) and makes decoding backward-compatible by falling back to the old uncompressed base58 format (and existing legacy base64url/percent-decoding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa9bdc2949902957895739c4199ff89c6b61b579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->