### PR TITLE
fix: replace Disconnect with Back button on namespace join error

### DIFF
--- a/app/src/components/popups/NamespaceEntryPopup.tsx
+++ b/app/src/components/popups/NamespaceEntryPopup.tsx
@@ -915,9 +915,9 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
                 type="button"
                 variant="secondary"
                 style={{ flex: 1 }}
-                onClick={onLogout}
+                onClick={() => { setError(""); setStep(namespaces.length > 0 ? "select" : "no-workspace"); }}
               >
-                Disconnect
+                ← Back
               </Button>
             </Row>
           </>


### PR DESCRIPTION
## Summary

- On namespace join failure, the "Disconnect" button is replaced with a "← Back" button
- Back navigates to the namespace selector (`select` step) if namespaces are available, otherwise to the `no-workspace` screen (create or join via invitation)
- "Retry" button is unchanged

## Before / After

**Before:** Retry | Disconnect  
**After:** Retry | ← Back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change in the error state; it alters navigation/flow but does not touch auth, data writes, or API behavior.
> 
> **Overview**
> On the namespace entry error screen (`step === "error"`) replaces the secondary action from **Disconnect** (`onLogout`) to a **← Back** button.
> 
> The new back action clears the error and returns users to workspace selection (`select`) when namespaces are available, otherwise to the `no-workspace` onboarding step; **Retry** behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3efb4c0a995286a396d08c7df9bfba39a4492d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->