### PR TITLE
fix: auto-join restricted subgroup contexts before MemberAdded propagates

### DIFF
--- a/app/src/hooks/useGroupContexts.ts
+++ b/app/src/hooks/useGroupContexts.ts
@@ -72,23 +72,24 @@ export function useGroupContexts() {
             }
           })
         );
-        // Auto-join is scoped to subgroups where we are a DIRECT member
-        // (admin added us via `add_group_members`, or we created/joined
-        // explicitly). `listMembers(subgroupId)` is the canonical signal:
-        // inherited members via `CAN_JOIN_OPEN_SUBGROUPS` on the
-        // namespace root are NOT in that list, so they correctly skip
-        // auto-join — Open-subgroup discovery stays opt-in (the user
-        // clicks "Join" in the sidebar).
+        // Auto-join gate — two cases trigger it:
         //
-        // The trigger we DO want to keep firing: admin adds a member to
-        // a Restricted subgroup. `add_group_members` publishes
-        // MemberAdded + KeyDelivery, but never materialises the local
-        // `ContextIdentity` row on the added member's node (auto_follow
-        // only fires on ContextRegistered / AutoFollowSet — see
-        // [[project-curb-governance-quirks]]). Without this call, the
-        // member never sees the context, can't decrypt, and the
-        // "admin added me to a private channel" flow looks broken.
-        if (isDirectMember) {
+        // 1. isDirectMember=true: `listMembers(subgroupId)` confirmed us.
+        //    Covers admin adding us via `add_group_members` once the
+        //    MemberAdded governance op has propagated to this node.
+        //
+        // 2. visibility !== "open": for Restricted (or not-yet-known)
+        //    subgroups we also attempt auto-join and let the server decide.
+        //    On cross-network setups the MemberAdded gossipsub op is often
+        //    missed (0 acks, 90 s heartbeat delay), so `listMembers` returns
+        //    us as a non-member even though the node has already received the
+        //    op. Calling joinGroupContext here is safe: the server rejects
+        //    joins we are not entitled to (returns an error we already
+        //    swallow), and succeeds as soon as the node's governance state
+        //    catches up — no extra frontend polling round-trip needed.
+        //    Open subgroups are explicitly excluded: discovery there stays
+        //    opt-in (user clicks "Join" in the sidebar).
+        if (isDirectMember || visibility !== "open") {
           await Promise.all(
             ids.filter((id) => !idMap[id]).map(async (ctxId) => {
               try {


### PR DESCRIPTION
## What broke and why

Logs from two nodes on different networks showed a consistent pattern:

1. Node 1 creates a subgroup + context, broadcasts `GroupCreated` + `ContextRegistered` + `MemberAdded` governance ops
2. **Gossipsub mesh miss** — all three ops have `elapsed_ms=5001, acks=0`; they fall back to the 90 s heartbeat
3. On node 2: `ContextRegistered` arrives quickly (via DAG sync), so `listGroupContexts` returns the context ID — **but** `listMembers` still shows node 2 as a non-member because `MemberAdded` hasn't arrived yet
4. `isDirectMember = false` → auto-join is skipped entirely
5. User sees subgroups in the sidebar but contexts never appear

This only manifests on **different machines across a network** — on localhost gossipsub propagates instantly so `isDirectMember` is correct by the time the frontend polls.

## Fix

In `useGroupContexts.ts`, change the auto-join gate from `isDirectMember` to `isDirectMember || visibility !== "open"`:

- **Restricted / unknown-visibility subgroups**: always attempt `joinGroupContext` and let the server decide. The server rejects joins the node isn't entitled to (already handled by existing error swallow), and accepts as soon as its local governance state has received `MemberAdded` — no extra frontend polling round-trip needed on top of the propagation delay.
- **Open subgroups**: unchanged — opt-in via "Join" button in the sidebar.

## Why it's safe

- `joinGroupContext` errors are already silently swallowed with a `log.debug`
- The server is the authority on membership — a spurious call during the propagation window just gets rejected and retried on the next 30 s poll
- Open subgroup auto-join behavior is explicitly preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the client-side auto-join gate for subgroup contexts, which can increase join attempts and affect channel visibility/timing if server-side membership/visibility rules behave unexpectedly. Security risk is limited since the server remains authoritative and join errors are already handled.
> 
> **Overview**
> Fixes a propagation race where restricted subgroup contexts could appear in the UI but never become joinable if `MemberAdded` hasn’t reached the node yet.
> 
> `useGroupContexts` now attempts `joinGroupContext` not only when `isDirectMember` is true, but also for any subgroup whose visibility is not `open`, relying on server-side authorization; open subgroups remain opt-in (no auto-join).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b4cf420f8083d536738c5398eab07cbcebe5f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->