### PR TITLE
fix(workflows): serialize node writes to prevent CRDT fork timeouts

### DIFF
--- a/workflows/dm.yml
+++ b/workflows/dm.yml
@@ -167,9 +167,15 @@ steps:
       images: null
     executor_public_key: "{{alice_dm_key}}"
 
-  - name: Wait before Bob DM reply
-    type: wait
-    seconds: 5
+  - name: Sync Alice DM before Bob replies
+    type: wait_for_sync
+    context_id: "{{dm_ctx_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob replies in DM
     type: call

--- a/workflows/e2e-v2.yml
+++ b/workflows/e2e-v2.yml
@@ -141,9 +141,15 @@ steps:
       avatar: null
     executor_public_key: "{{alice_key}}"
 
-  - name: Wait before Bob profile
-    type: wait
-    seconds: 5
+  - name: Sync Alice profile before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob sets profile
     type: call
@@ -211,9 +217,15 @@ steps:
       images: null
     executor_public_key: "{{alice_key}}"
 
-  - name: Wait before Bob message
-    type: wait
-    seconds: 5
+  - name: Sync Alice message before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob sends message
     type: call

--- a/workflows/e2e.yml
+++ b/workflows/e2e.yml
@@ -7,10 +7,6 @@ description: >
 
 force_pull_image: true
 
-# TODO BEFORE MERGE: change image tag back to :edge (or latest stable release)
-# — rc.39 is pinned here to match the local dev binary. All workflow files
-# (dm.yml, governance.yml, integration-setup.yml, non-admin-creates.yml,
-# e2e-v2.yml) need the same change, plus logic/Cargo.toml calimero-sdk deps.
 nodes:
   chain_id: testnet-1
   count: 3
@@ -208,9 +204,16 @@ steps:
     statements:
       - "contains({{alice_profile_result}}, 'Profile set')"
 
-  - name: Wait before Bob profile
-    type: wait
-    seconds: 5
+  - name: Sync Alice profile before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Set Profile - Bob (Node 2)
     type: call
@@ -222,9 +225,16 @@ steps:
       username: Bob
       avatar: null
 
-  - name: Wait before Carol profile
-    type: wait
-    seconds: 5
+  - name: Sync Bob profile before Carol writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Set Profile - Carol (Node 3)
     type: call
@@ -243,7 +253,7 @@ steps:
       - calimero-node-1
       - calimero-node-2
       - calimero-node-3
-    timeout: 120
+    timeout: 60
     check_interval: 2
     trigger_sync: true
 
@@ -303,9 +313,16 @@ steps:
     statements:
       - "contains({{alice_msg}}, 'Hello everyone from Alice!')"
 
-  - name: Wait before Bob message
-    type: wait
-    seconds: 5
+  - name: Sync Alice message before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob Sends Message
     type: call
@@ -323,9 +340,16 @@ steps:
       files: null
       images: null
 
-  - name: Wait before Carol message
-    type: wait
-    seconds: 5
+  - name: Sync Bob message before Carol writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Carol Sends Searchable Message
     type: call
@@ -350,7 +374,7 @@ steps:
       - calimero-node-1
       - calimero-node-2
       - calimero-node-3
-    timeout: 120
+    timeout: 60
     check_interval: 2
     trigger_sync: true
 
@@ -552,9 +576,15 @@ steps:
       files: null
       images: null
 
-  - name: Wait before Bob DM reply
-    type: wait
-    seconds: 5
+  - name: Sync Alice DM before Bob replies
+    type: wait_for_sync
+    context_id: "{{dm_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob Replies in DM
     type: call

--- a/workflows/integration-setup.yml
+++ b/workflows/integration-setup.yml
@@ -102,9 +102,18 @@ steps:
       username: Alice
       avatar: null
 
-  - name: Wait before Bob profile
-    type: wait
-    seconds: 5
+  # Sync Alice's profile to node-2 before Bob writes, so writes are linear
+  # (no concurrent-write fork). Without this, node-1 and node-2 diverge and
+  # wait_for_sync below can never converge the two branches within the timeout.
+  - name: Sync Alice profile to Node 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Set Profile - Node 2 (Bob)
     type: call
@@ -143,9 +152,17 @@ steps:
       files: null
       images: null
 
-  - name: Wait before Bob message
-    type: wait
-    seconds: 5
+  # Sync Alice's message to node-2 before Bob writes — same fork-prevention
+  # pattern as the profile steps above.
+  - name: Sync Alice message to Node 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Seed Message - Bob
     type: call


### PR DESCRIPTION
## Summary
- Root cause: when two nodes write concurrently (Alice on node-1, Bob on node-2 with only a 5s sleep between), they create diverging CRDT DAG branches. `wait_for_sync` then has to wait for merod to gossip and merge them — under rc.41 CI latency this never completes within 60s, causing the \"Sync verification failed after 61.25s\" failure.
- Fix: add an intermediate `wait_for_sync` + `trigger_sync: true` between each pair of cross-node writes in all four workflow files. Every write now builds on a fully-propagated base, keeping the DAG linear and making the final sync step trivial.
- Applies to: `integration-setup.yml` (profiles + messages), `e2e.yml` (profiles, channel messages, DM messages), `e2e-v2.yml` (profiles + messages), `dm.yml` (DM messages).
- Also removes a stale rc.39 TODO comment from `e2e.yml`.

## Test plan
- [ ] CI integration workflow passes (`Wait for Profile Sync` no longer times out)
- [ ] `wait_for_sync` steps after Bob's writes complete quickly since state is already linear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only test workflow timing/synchronization is adjusted to reduce flaky CRDT sync timeouts, with no production code changes.
> 
> **Overview**
> Adds intermediate `wait_for_sync` steps (with `trigger_sync: true`) between sequential writes across nodes in `dm.yml`, `e2e-v2.yml`, `e2e.yml`, and `integration-setup.yml`, replacing the previous `wait: 5s` delays to **serialize state mutations** and avoid divergent CRDT branches.
> 
> Also tightens some `wait_for_sync` `timeout` values from `120` to `60` in `e2e.yml` and removes an outdated TODO comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70731a17194f231a26e4c938d389ccc853258525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->