### PR TITLE
Fix/integration ci profile sync fork

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -61,7 +61,7 @@ jobs:
       # ── Install merobox ───────────────────────────────────────────────────────
 
       - name: Install merobox
-        run: pip install merobox==0.6.14 && merobox --version
+        run: pip install merobox==0.6.15 && merobox --version
 
       # ── Start nodes + install curb app + create context + seed messages ───────
       # integration-setup.yml sets stop_all_nodes: false so nodes stay running.

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -58,7 +58,7 @@ jobs:
           cp target/wasm32-unknown-unknown/app-release/curb.wasm res/
 
       - name: Install merobox
-        run: pip install merobox==0.6.14 && merobox --version
+        run: pip install merobox==0.6.15 && merobox --version
 
       - name: Run E2E workflow (3-node)
         working-directory: workflows

--- a/app/src/components/popups/CreateWorkspacePopup.test.tsx
+++ b/app/src/components/popups/CreateWorkspacePopup.test.tsx
@@ -182,7 +182,7 @@ describe("CreateWorkspacePopup", () => {
     await waitFor(() => {
       expect(mockCreateGroup).toHaveBeenCalledWith({
         applicationId: "app-1",
-        upgradePolicy: "LazyOnAccess",
+        upgradePolicy: "Automatic",
         alias: "Team Space",
       });
     });

--- a/app/src/components/popups/CreateWorkspacePopup.tsx
+++ b/app/src/components/popups/CreateWorkspacePopup.tsx
@@ -10,6 +10,7 @@ import {
   setGroupId,
   setGroupMemberIdentity,
 } from "../../constants/config";
+import { DEFAULT_MEMBER_CAPABILITIES } from "../../utils/groupCapabilities";
 
 const Overlay = styled.div`
   position: fixed;
@@ -173,7 +174,7 @@ export default function CreateWorkspacePopup({
       const applicationId = await resolveApplicationId(configuredApplicationId);
       const groupResult = await groupApi.createGroup({
         applicationId,
-        upgradePolicy: "LazyOnAccess",
+        upgradePolicy: "Automatic",
         alias: trimmedWorkspaceName,
       });
       if (groupResult.error || !groupResult.data) {
@@ -182,8 +183,7 @@ export default function CreateWorkspacePopup({
       const groupId = groupResult.data.groupId;
       setGroupId(groupId);
 
-      // Allow all members to create contexts, invite others, and join open subgroups (0x0F = 0b1111)
-      await groupApi.setDefaultCapabilities(groupId, { defaultCapabilities: 0x0F });
+      await groupApi.setDefaultCapabilities(groupId, { defaultCapabilities: DEFAULT_MEMBER_CAPABILITIES });
 
       const identityResult = await groupApi.resolveCurrentMemberIdentity(groupId);
       if (identityResult.data?.memberIdentity) {

--- a/app/src/components/popups/NamespaceEntryPopup.tsx
+++ b/app/src/components/popups/NamespaceEntryPopup.tsx
@@ -25,6 +25,7 @@ import {
   setIdentityDisplayName,
 } from "../../utils/messengerName";
 import { clearStoredSession, setNamespaceReady } from "../../utils/session";
+import { DEFAULT_MEMBER_CAPABILITIES } from "../../utils/groupCapabilities";
 import {
   extractInvitationFromUrl,
   getInvitationFromStorage,
@@ -586,7 +587,7 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
       const appId = await resolveAppId(getApplicationId());
       const createRes = await api.current.createGroup({
         applicationId: appId,
-        upgradePolicy: "LazyOnAccess",
+        upgradePolicy: "Automatic",
         alias: trimmedNs,
       });
       if (createRes.error || !createRes.data) {
@@ -595,7 +596,7 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
 
       const { groupId } = createRes.data;
 
-      await api.current.setDefaultCapabilities(groupId, { defaultCapabilities: 0x0F }).catch(() => {});
+      await api.current.setDefaultCapabilities(groupId, { defaultCapabilities: DEFAULT_MEMBER_CAPABILITIES }).catch(() => {});
 
       // Create initial "general" channel so the namespace has something to chat in
       try {
@@ -623,7 +624,7 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
         alias: trimmedNs,
         appKey: "",
         targetApplicationId: "",
-        upgradePolicy: "LazyOnAccess",
+        upgradePolicy: "Automatic",
         createdAt: Math.floor(Date.now() / 1000),
       }]);
       setSelectedId(groupId);

--- a/workflows/dm.yml
+++ b/workflows/dm.yml
@@ -167,9 +167,15 @@ steps:
       images: null
     executor_public_key: "{{alice_dm_key}}"
 
-  - name: Wait before Bob DM reply
-    type: wait
-    seconds: 5
+  - name: Sync Alice DM before Bob replies
+    type: wait_for_sync
+    context_id: "{{dm_ctx_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob replies in DM
     type: call

--- a/workflows/dm.yml
+++ b/workflows/dm.yml
@@ -25,7 +25,7 @@ force_pull_image: true
 nodes:
   chain_id: testnet-1
   count: 2
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.41
+  image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node
 
 steps:

--- a/workflows/e2e-v2.yml
+++ b/workflows/e2e-v2.yml
@@ -21,7 +21,7 @@ force_pull_image: true
 nodes:
   chain_id: testnet-1
   count: 2
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.41
+  image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node
 
 steps:

--- a/workflows/e2e-v2.yml
+++ b/workflows/e2e-v2.yml
@@ -141,9 +141,15 @@ steps:
       avatar: null
     executor_public_key: "{{alice_key}}"
 
-  - name: Wait before Bob profile
-    type: wait
-    seconds: 5
+  - name: Sync Alice profile before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob sets profile
     type: call
@@ -211,9 +217,15 @@ steps:
       images: null
     executor_public_key: "{{alice_key}}"
 
-  - name: Wait before Bob message
-    type: wait
-    seconds: 5
+  - name: Sync Alice message before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob sends message
     type: call

--- a/workflows/e2e.yml
+++ b/workflows/e2e.yml
@@ -7,10 +7,6 @@ description: >
 
 force_pull_image: true
 
-# TODO BEFORE MERGE: change image tag back to :edge (or latest stable release)
-# — rc.39 is pinned here to match the local dev binary. All workflow files
-# (dm.yml, governance.yml, integration-setup.yml, non-admin-creates.yml,
-# e2e-v2.yml) need the same change, plus logic/Cargo.toml calimero-sdk deps.
 nodes:
   chain_id: testnet-1
   count: 3
@@ -208,9 +204,16 @@ steps:
     statements:
       - "contains({{alice_profile_result}}, 'Profile set')"
 
-  - name: Wait before Bob profile
-    type: wait
-    seconds: 5
+  - name: Sync Alice profile before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Set Profile - Bob (Node 2)
     type: call
@@ -222,9 +225,16 @@ steps:
       username: Bob
       avatar: null
 
-  - name: Wait before Carol profile
-    type: wait
-    seconds: 5
+  - name: Sync Bob profile before Carol writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Set Profile - Carol (Node 3)
     type: call
@@ -243,7 +253,7 @@ steps:
       - calimero-node-1
       - calimero-node-2
       - calimero-node-3
-    timeout: 120
+    timeout: 60
     check_interval: 2
     trigger_sync: true
 
@@ -303,9 +313,16 @@ steps:
     statements:
       - "contains({{alice_msg}}, 'Hello everyone from Alice!')"
 
-  - name: Wait before Bob message
-    type: wait
-    seconds: 5
+  - name: Sync Alice message before Bob writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob Sends Message
     type: call
@@ -323,9 +340,16 @@ steps:
       files: null
       images: null
 
-  - name: Wait before Carol message
-    type: wait
-    seconds: 5
+  - name: Sync Bob message before Carol writes
+    type: wait_for_sync
+    context_id: "{{channel_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+      - calimero-node-3
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Carol Sends Searchable Message
     type: call
@@ -350,7 +374,7 @@ steps:
       - calimero-node-1
       - calimero-node-2
       - calimero-node-3
-    timeout: 120
+    timeout: 60
     check_interval: 2
     trigger_sync: true
 
@@ -552,9 +576,15 @@ steps:
       files: null
       images: null
 
-  - name: Wait before Bob DM reply
-    type: wait
-    seconds: 5
+  - name: Sync Alice DM before Bob replies
+    type: wait_for_sync
+    context_id: "{{dm_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Bob Replies in DM
     type: call

--- a/workflows/e2e.yml
+++ b/workflows/e2e.yml
@@ -10,7 +10,7 @@ force_pull_image: true
 nodes:
   chain_id: testnet-1
   count: 3
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.41
+  image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node
 
 steps:

--- a/workflows/integration-setup.yml
+++ b/workflows/integration-setup.yml
@@ -102,9 +102,18 @@ steps:
       username: Alice
       avatar: null
 
-  - name: Wait before Bob profile
-    type: wait
-    seconds: 5
+  # Sync Alice's profile to node-2 before Bob writes, so writes are linear
+  # (no concurrent-write fork). Without this, node-1 and node-2 diverge and
+  # wait_for_sync below can never converge the two branches within the timeout.
+  - name: Sync Alice profile to Node 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Set Profile - Node 2 (Bob)
     type: call
@@ -143,9 +152,17 @@ steps:
       files: null
       images: null
 
-  - name: Wait before Bob message
-    type: wait
-    seconds: 5
+  # Sync Alice's message to node-2 before Bob writes — same fork-prevention
+  # pattern as the profile steps above.
+  - name: Sync Alice message to Node 2
+    type: wait_for_sync
+    context_id: "{{context_id}}"
+    nodes:
+      - calimero-node-1
+      - calimero-node-2
+    timeout: 60
+    check_interval: 2
+    trigger_sync: true
 
   - name: Seed Message - Bob
     type: call

--- a/workflows/integration-setup.yml
+++ b/workflows/integration-setup.yml
@@ -16,7 +16,7 @@ wait_timeout: 120
 nodes:
   chain_id: testnet-1
   count: 2
-  image: ghcr.io/calimero-network/merod:0.10.1-rc.41
+  image: ghcr.io/calimero-network/merod:edge
   prefix: calimero-node
 
 steps:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: adjusts merobox/merod versions and adds sync barriers in E2E workflows, which can change CI behavior and timing; also changes workspace creation defaults (`upgradePolicy` and capability mask) that affect newly created groups.
> 
> **Overview**
> Stabilizes merobox-based integration/E2E runs by upgrading `merobox` to `0.6.15`, switching workflow node images to `ghcr.io/calimero-network/merod:edge`, and replacing fixed `wait` delays with `wait_for_sync` gates before cross-node writes to prevent CRDT fork/divergence (with tighter 60s sync timeouts).
> 
> Updates workspace/namespace creation in the frontend to use `upgradePolicy: "Automatic"` (instead of `LazyOnAccess`) and centralizes the default member capability mask via `DEFAULT_MEMBER_CAPABILITIES`; corresponding unit test expectations are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6da23537d6b09a5d305cca7344408931deb566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->