### PR TITLE
feat: settings UX, profile avatar upload, WASM message drafts

### DIFF
--- a/app/dev-dist/sw.js
+++ b/app/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-c6a197bf'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.kl00mn73prs"
+    "revision": "0.lctposhb5bk"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/app/src/api/clientApi.ts
+++ b/app/src/api/clientApi.ts
@@ -287,6 +287,10 @@ export enum ClientMethod {
   GET_UNREAD_COUNT = "get_unread_count",
   GET_UNREAD_MENTIONS = "get_unread_mentions",
   SEARCH_ALL_MESSAGES = "search_all_messages",
+  // Per-user per-channel drafts (WASM-backed, effectively private).
+  SAVE_DRAFT = "save_draft",
+  GET_DRAFT = "get_draft",
+  DELETE_DRAFT = "delete_draft",
 }
 
 /// Per-context moderation role. Mirrors the Rust `Role` enum.

--- a/app/src/api/dataSource/clientApiDataSource.ts
+++ b/app/src/api/dataSource/clientApiDataSource.ts
@@ -1648,7 +1648,7 @@ export class ClientApiDataSource implements ClientApi {
         return {
           data: null,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          error: { code: response.error.code, message: (response.error.error.cause.info as any).message },
+          error: { code: response.error.code, message: (response.error.error?.cause?.info as any)?.message ?? "saveDraft failed" },
         };
       }
       return { data: undefined, error: null };
@@ -1731,7 +1731,7 @@ export class ClientApiDataSource implements ClientApi {
           error: {
             code: response.error.code,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            message: (response.error.error.cause.info as any).message,
+            message: (response.error.error?.cause?.info as any)?.message ?? "updateProfile failed",
           },
         };
       }

--- a/app/src/api/dataSource/clientApiDataSource.ts
+++ b/app/src/api/dataSource/clientApiDataSource.ts
@@ -1626,4 +1626,119 @@ export class ClientApiDataSource implements ClientApi {
       return { data: 0, error: null };
     }
   }
+
+  async saveDraft(
+    contextId: string,
+    executorPublicKey: string,
+    channel: string,
+    text: string,
+  ): ApiResponse<void> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await getJsonRpcClient().execute<any, void>(
+        {
+          contextId,
+          method: ClientMethod.SAVE_DRAFT,
+          argsJson: { channel, text },
+          executorPublicKey,
+        },
+        { headers: { "Content-Type": "application/json" }, timeout: 5000 },
+      );
+      if (response?.error) {
+        return {
+          data: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          error: { code: response.error.code, message: (response.error.error.cause.info as any).message },
+        };
+      }
+      return { data: undefined, error: null };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "saveDraft failed";
+      return { data: null, error: { code: 500, message } };
+    }
+  }
+
+  async getDraft(
+    contextId: string,
+    executorPublicKey: string,
+    channel: string,
+  ): ApiResponse<string> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await getJsonRpcClient().execute<any, string>(
+        {
+          contextId,
+          method: ClientMethod.GET_DRAFT,
+          argsJson: { channel },
+          executorPublicKey,
+        },
+        { headers: { "Content-Type": "application/json" }, timeout: 5000 },
+      );
+      if (response?.error) {
+        return { data: "", error: null };
+      }
+      return { data: (response?.result.output as string) ?? "", error: null };
+    } catch {
+      return { data: "", error: null };
+    }
+  }
+
+  async deleteDraft(
+    contextId: string,
+    executorPublicKey: string,
+    channel: string,
+  ): ApiResponse<void> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await getJsonRpcClient().execute<any, void>(
+        {
+          contextId,
+          method: ClientMethod.DELETE_DRAFT,
+          argsJson: { channel },
+          executorPublicKey,
+        },
+        { headers: { "Content-Type": "application/json" }, timeout: 5000 },
+      );
+      if (response?.error) {
+        return { data: null, error: { code: response.error.code, message: "deleteDraft failed" } };
+      }
+      return { data: undefined, error: null };
+    } catch {
+      return { data: null, error: { code: 500, message: "deleteDraft failed" } };
+    }
+  }
+
+  async updateProfile(
+    contextId: string,
+    executorPublicKey: string,
+    username: string,
+    avatar: string | null,
+  ): ApiResponse<string> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const response = await getJsonRpcClient().execute<any, string>(
+        {
+          contextId,
+          method: "set_profile",
+          argsJson: { username, avatar },
+          executorPublicKey,
+        },
+        { headers: { "Content-Type": "application/json" }, timeout: 10000 },
+      );
+      if (response?.error) {
+        return {
+          data: null,
+          error: {
+            code: response.error.code,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            message: (response.error.error.cause.info as any).message,
+          },
+        };
+      }
+      return { data: response?.result.output as string, error: null };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "updateProfile failed";
+      return { data: null, error: { code: 500, message } };
+    }
+  }
 }

--- a/app/src/chat/MessageInput.tsx
+++ b/app/src/chat/MessageInput.tsx
@@ -696,6 +696,12 @@ export default function MessageInput({
         // P2P sync found no connected peers — expected with a single node.
         // Don't surface this as an error to the user.
         if (/mesh|no.*peer|peer.*sync/i.test(message)) {
+          if (!isThread) clearDraft();
+          clearUploadedImage();
+          clearUploadedFile();
+          setShowUpload(false);
+          setEmojiSelectorOpen(false);
+          handleMessageChange(null);
           return;
         }
         addToast({

--- a/app/src/chat/MessageInput.tsx
+++ b/app/src/chat/MessageInput.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { useDraft } from "../hooks/useDraft";
 import { styled } from "styled-components";
 import type {
   AttachmentDraft,
@@ -318,6 +319,17 @@ const Placeholder = styled.div<{
   }
 `;
 
+const DraftBadge = styled.span`
+  font-size: 0.66rem;
+  color: rgba(255, 255, 255, 0.3);
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+`;
+
 const ReadOnlyField = styled.div<{ $banned?: boolean }>`
   background-color: ${(p) => (p.$banned ? "rgba(255, 59, 59, 0.07)" : "#111111")};
   border: 1px solid
@@ -423,6 +435,12 @@ export default function MessageInput({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const editorRef = useRef<any>(null);
   const { addToast } = useToast();
+  // Drafts: disabled for thread replies to keep things simple.
+  const { draft: channelDraft, hasDraft, setDraft, clearDraft } = useDraft(
+    isThread ? undefined : selectedChat,
+  );
+  // Tracks which channel's draft has already been applied to the editor.
+  const draftAppliedRef = useRef<string | undefined>(undefined);
 
   const deleteBlobById = useCallback(async (blobId?: string) => {
     if (!blobId) {
@@ -535,7 +553,29 @@ export default function MessageInput({
     setShowUpload(false);
     clearUploadedFile();
     clearUploadedImage();
+    // Allow the draft for the new channel to be applied once it loads.
+    draftAppliedRef.current = undefined;
   }, [selectedChat, clearUploadedFile, clearUploadedImage]);
+
+  // Pre-populate the editor with the persisted draft when it loads.
+  useEffect(() => {
+    if (!channelDraft || isThread) return;
+    if (draftAppliedRef.current === selectedChat) return;
+    draftAppliedRef.current = selectedChat;
+    setMessage({
+      id: "",
+      text: channelDraft,
+      nonce: "",
+      timestamp: Date.now(),
+      sender: "",
+      reactions: new Map(),
+      files: [],
+      images: [],
+      thread_count: 0,
+      thread_last_timestamp: 0,
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [channelDraft]);
 
   const removeUploadedFile = useCallback(() => {
     if (uploadedFile?.file.blobId) {
@@ -638,6 +678,7 @@ export default function MessageInput({
 
       try {
         await sendMessage(payload);
+        if (!isThread) clearDraft();
         clearUploadedImage();
         clearUploadedFile();
         setShowUpload(false);
@@ -672,6 +713,8 @@ export default function MessageInput({
       setEmojiSelectorOpen,
       handleMessageChange,
       addToast,
+      clearDraft,
+      isThread,
     ]
   );
 
@@ -762,6 +805,7 @@ export default function MessageInput({
                             thread_last_timestamp: 0,
                           }
                     );
+                    if (!isThread) setDraft(value);
                   }}
                   onSend={handleSendMessageEnter}
                   placeholder={placeholderText}
@@ -809,6 +853,7 @@ export default function MessageInput({
             </>
           </Wrapper>
           <ActionsWrapper>
+            {hasDraft && !isThread && <DraftBadge>Draft</DraftBadge>}
             <IconUpload onClick={toggleUploadPopup} />
             <div onClick={toggleEmojiPopup}>
               <IconEmoji />

--- a/app/src/chat/MessageInput.tsx
+++ b/app/src/chat/MessageInput.tsx
@@ -805,7 +805,12 @@ export default function MessageInput({
                             thread_last_timestamp: 0,
                           }
                     );
-                    if (!isThread) setDraft(value);
+                    if (!isThread) {
+                      // Mark draft as applied so the pre-populate effect doesn't
+                      // fire again on the channelDraft change caused by this keystroke.
+                      draftAppliedRef.current = selectedChat;
+                      setDraft(value);
+                    }
                   }}
                   onSend={handleSendMessageEnter}
                   placeholder={placeholderText}

--- a/app/src/chat/MessageInput.tsx
+++ b/app/src/chat/MessageInput.tsx
@@ -557,6 +557,11 @@ export default function MessageInput({
     draftAppliedRef.current = undefined;
   }, [selectedChat, clearUploadedFile, clearUploadedImage]);
 
+  // When a thread closes, reset the ref so the channel draft is re-applied.
+  useEffect(() => {
+    if (!isThread) draftAppliedRef.current = undefined;
+  }, [isThread]);
+
   // Pre-populate the editor with the persisted draft when it loads.
   useEffect(() => {
     if (!channelDraft || isThread) return;

--- a/app/src/chat/SearchResultMessage.tsx
+++ b/app/src/chat/SearchResultMessage.tsx
@@ -198,6 +198,7 @@ export default function SearchResultMessage({
           <IdentityAvatar
             size="md"
             identity={message.sender}
+            contextId={contextId}
             name={displayName || message.sender}
           />
         </AvatarWrapper>

--- a/app/src/chat/SearchResultMessage.tsx
+++ b/app/src/chat/SearchResultMessage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback } from "react";
 import { styled } from "styled-components";
 import type { CurbFile, CurbMessage, FileObject } from "../types/Common";
-import Avatar from "../components/virtualized-chat/Message/Avatar";
+import { IdentityAvatar } from "../components/IdentityAvatar";
 import RenderHtml from "../components/virtualized-chat/Message/RenderHtml";
 import MessageImageField from "./MessageImageField";
 import MessageFileField from "./MessageFileField";
@@ -195,10 +195,10 @@ export default function SearchResultMessage({
       )}
       <Header>
         <AvatarWrapper>
-          <Avatar
+          <IdentityAvatar
             size="md"
+            identity={message.sender}
             name={displayName || message.sender}
-            alt={displayName || message.sender}
           />
         </AvatarWrapper>
         <SenderBlock>

--- a/app/src/components/IdentityAvatar.tsx
+++ b/app/src/components/IdentityAvatar.tsx
@@ -1,0 +1,37 @@
+import React, { memo } from "react";
+import { getContextId } from "@calimero-network/mero-react";
+import { useAvatarUrl } from "../hooks/useAvatarUrl";
+import { Avatar } from "./virtualized-chat/Message/Avatar";
+
+interface IdentityAvatarProps {
+  identity: string | undefined;
+  contextId?: string;
+  name?: string;
+  size?: "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/** Renders an avatar circle with an async-loaded profile image.
+ *  Falls back to the initials circle if no avatar is set or while loading. */
+export const IdentityAvatar = memo(function IdentityAvatar({
+  identity,
+  contextId,
+  name,
+  size = "md",
+  className,
+  style,
+}: IdentityAvatarProps) {
+  const resolvedContextId = contextId ?? getContextId() ?? undefined;
+  const avatarUrl = useAvatarUrl(identity, resolvedContextId);
+
+  return (
+    <Avatar
+      src={avatarUrl}
+      name={name}
+      size={size}
+      className={className}
+      style={style}
+    />
+  );
+});

--- a/app/src/components/admin/MembersTab.test.tsx
+++ b/app/src/components/admin/MembersTab.test.tsx
@@ -6,6 +6,10 @@ vi.mock("@calimero-network/mero-ui", () => ({
   Avatar: ({ name }: { name: string }) => <div>{name}</div>,
 }));
 
+vi.mock("../IdentityAvatar", () => ({
+  IdentityAvatar: ({ name }: { name: string }) => <div>{name}</div>,
+}));
+
 vi.mock("../popups/ConfirmPopup", () => ({
   default: ({ toggle }: { toggle: React.ReactNode }) => <>{toggle}</>,
 }));

--- a/app/src/components/admin/MembersTab.tsx
+++ b/app/src/components/admin/MembersTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
-import { Avatar } from "@calimero-network/mero-ui";
+import { IdentityAvatar } from "../IdentityAvatar";
 import type { GroupMember, MemberCapabilities } from "../../api/groupApi";
 import ConfirmPopup from "../popups/ConfirmPopup";
 import {
@@ -253,7 +253,7 @@ export default function MembersTab({
         <React.Fragment key={member.identity}>
           <MemberRow>
             <MemberInfo>
-              <Avatar size="xs" name={getMemberDisplayName(member)} />
+              <IdentityAvatar size="xs" identity={member.identity} name={getMemberDisplayName(member)} />
               <IdentityStack>
                 <Identity title={member.identity}>
                   {getMemberDisplayName(member)}

--- a/app/src/components/navbar/UsersButtonGroup.tsx
+++ b/app/src/components/navbar/UsersButtonGroup.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { useState } from "react";
-import { Avatar } from "@calimero-network/mero-ui";
+import { IdentityAvatar } from "../IdentityAvatar";
 
 interface UsersButtonGroupProps {
   channelUserList: Map<string, string>;
@@ -57,7 +57,7 @@ export default function UsersButtonGroup(props: UsersButtonGroupProps) {
         .map(([publicKey, userName]) => (
           <div key={publicKey}>
             <ProfileIconContainerGroup $isHovered={isHovered}>
-              <Avatar size="xs" name={userName} />
+              <IdentityAvatar size="xs" identity={publicKey} name={userName} />
             </ProfileIconContainerGroup>
           </div>
         ))}

--- a/app/src/components/popups/SettingsPopup.tsx
+++ b/app/src/components/popups/SettingsPopup.tsx
@@ -521,26 +521,37 @@ export default function SettingsPopup({
         avatarObjectUrlRef.current = newUrl;
         setAvatarObjectUrl(newUrl);
 
-        // Propagate to every channel/DM context the user is a member of.
+        // Always update the currently-active context first (fallback when
+        // listGroupContexts is stale or returns empty — e.g. after make stop).
+        const currentContextId = getContextId();
+        const currentIdentity = getExecutorPublicKey();
+        const clientDs = new ClientApiDataSource();
+        if (currentContextId && currentIdentity) {
+          try {
+            await clientDs.updateProfile(currentContextId, currentIdentity, username, blobId);
+          } catch {
+            // best-effort
+          }
+        }
+
+        // Best-effort: propagate to every other context in the group.
         const contextsRes = await new GroupApiDataSource().listGroupContexts(groupId);
-        if (contextsRes.data) {
-          const clientDs = new ClientApiDataSource();
-          for (const ctx of contextsRes.data) {
-            try {
-              const owned = await getMeroJs().admin.getContextIdentitiesOwned(ctx.contextId);
-              const executorKey = owned.identities?.[0];
-              if (!executorKey) continue;
-              const profilesRes = await clientDs.getProfiles(ctx.contextId, executorKey);
-              const myProfile = profilesRes.data?.find((p) => p.identity === executorKey);
-              await clientDs.updateProfile(
-                ctx.contextId,
-                executorKey,
-                myProfile?.username || username,
-                blobId,
-              );
-            } catch {
-              // best-effort per context
-            }
+        for (const ctx of contextsRes.data ?? []) {
+          if (ctx.contextId === currentContextId) continue; // already done above
+          try {
+            const owned = await getMeroJs().admin.getContextIdentitiesOwned(ctx.contextId);
+            const executorKey = owned.identities?.[0];
+            if (!executorKey) continue;
+            const profilesRes = await clientDs.getProfiles(ctx.contextId, executorKey);
+            const myProfile = profilesRes.data?.find((p) => p.identity === executorKey);
+            await clientDs.updateProfile(
+              ctx.contextId,
+              executorKey,
+              myProfile?.username || username,
+              blobId,
+            );
+          } catch {
+            // best-effort per context
           }
         }
 

--- a/app/src/components/popups/SettingsPopup.tsx
+++ b/app/src/components/popups/SettingsPopup.tsx
@@ -465,6 +465,11 @@ export default function SettingsPopup({
 
     return () => {
       cancelled = true;
+      // Revoke the URL created in this run to prevent leaks on repeated opens.
+      if (avatarObjectUrlRef.current) {
+        URL.revokeObjectURL(avatarObjectUrlRef.current);
+        avatarObjectUrlRef.current = null;
+      }
     };
   }, [isOpen, identity]);
 

--- a/app/src/components/popups/SettingsPopup.tsx
+++ b/app/src/components/popups/SettingsPopup.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import { styled, keyframes } from "styled-components";
 import { useNavigate } from "react-router-dom";
 import BaseModal from "../common/popups/BaseModal";
-import { useMero, getContextIdentity as getExecutorPublicKey } from "@calimero-network/mero-react";
+import { useMero, getContextIdentity as getExecutorPublicKey, getContextId } from "@calimero-network/mero-react";
 import {
   clearStoredSession,
   clearSessionActivity,
@@ -15,13 +15,20 @@ import {
 } from "../../constants/config";
 import { clearMessengerDisplayName, getMessengerDisplayName } from "../../utils/messengerName";
 import { useCurrentGroupPermissions } from "../../hooks/useCurrentGroupPermissions";
-import { GroupApiDataSource } from "../../api/dataSource/groupApiDataSource";
+import { GroupApiDataSource, uploadBlobDirect } from "../../api/dataSource/groupApiDataSource";
+import { ClientApiDataSource } from "../../api/dataSource/clientApiDataSource";
+import { downloadBlob, getMeroJs } from "../../api/meroJsClient";
 import { useToast } from "../../contexts/ToastContext";
 // ─── Animations ────────────────────────────────────────────────────────────────
 
 const fadeIn = keyframes`
   from { opacity: 0; transform: translateY(6px); }
   to   { opacity: 1; transform: translateY(0); }
+`;
+
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
 `;
 
 // ─── Layout ────────────────────────────────────────────────────────────────────
@@ -133,6 +140,22 @@ const WorkspaceName = styled.span`
   text-overflow: ellipsis;
 `;
 
+const WorkspaceIdRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+`;
+
+const WorkspaceIdText = styled.span`
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.6);
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+`;
+
 const RoleBadge = styled.span<{ $admin: boolean; $mod?: boolean }>`
   flex-shrink: 0;
   font-size: 0.7rem;
@@ -161,11 +184,14 @@ const ProfileCard = styled.div`
   gap: 0.875rem;
 `;
 
-const ProfileAvatar = styled.div`
+const ProfileAvatar = styled.div<{ $hasImage: boolean }>`
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background: linear-gradient(135deg, rgba(87, 101, 242, 0.5) 0%, rgba(165, 255, 17, 0.2) 100%);
+  background: ${({ $hasImage }) =>
+    $hasImage
+      ? "transparent"
+      : "linear-gradient(135deg, rgba(87, 101, 242, 0.5) 0%, rgba(165, 255, 17, 0.2) 100%)"};
   border: 1px solid rgba(255, 255, 255, 0.1);
   display: flex;
   align-items: center;
@@ -175,6 +201,29 @@ const ProfileAvatar = styled.div`
   color: #fff;
   flex-shrink: 0;
   text-transform: uppercase;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+
+  &:hover > .avatar-overlay {
+    opacity: 1;
+  }
+`;
+
+const AvatarOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  border-radius: 50%;
+`;
+
+const SpinnerSvg = styled.svg`
+  animation: ${spin} 0.8s linear infinite;
 `;
 
 const ProfileInfo = styled.div`
@@ -309,19 +358,13 @@ const LogoutSection = styled.div`
   border-top: 1px solid rgba(255, 255, 255, 0.07);
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
 `;
 
 const SessionActions = styled.div`
   display: flex;
   align-items: center;
   gap: 0.625rem;
-`;
-
-const LogoutLabel = styled.span`
-  font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.3);
-  font-weight: 500;
 `;
 
 const SessionButton = styled.button`
@@ -379,11 +422,16 @@ export default function SettingsPopup({
   const navigate = useNavigate();
   const { addToast } = useToast();
   const groupId = getGroupId();
-  const namespaceName = getStoredGroupAlias(groupId) || groupId.slice(0, 12) + "…";
+  const alias = getStoredGroupAlias(groupId);
   const { isAdmin, isModerator } = useCurrentGroupPermissions(groupId);
   const [confirmLeave, setConfirmLeave] = useState(false);
   const [leaving, setLeaving] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedWorkspace, setCopiedWorkspace] = useState(false);
+  const [avatarObjectUrl, setAvatarObjectUrl] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const avatarInputRef = useRef<HTMLInputElement>(null);
+  const avatarObjectUrlRef = useRef<string | null>(null);
 
   const username = getMessengerDisplayName() || "";
   const identity = getExecutorPublicKey() || "";
@@ -391,6 +439,42 @@ export default function SettingsPopup({
     ? `${identity.slice(0, 8)}…${identity.slice(-6)}`
     : identity;
   const avatarInitial = username ? username[0] : identity[0] || "?";
+
+  // Load current avatar from the active context on open.
+  useEffect(() => {
+    if (!isOpen || !identity) return;
+    const contextId = getContextId();
+    if (!contextId) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await new ClientApiDataSource().getProfiles(contextId, identity);
+        const myProfile = res.data?.find((p) => p.identity === identity);
+        if (!myProfile?.avatar || cancelled) return;
+        const blob = await downloadBlob(myProfile.avatar, contextId);
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        avatarObjectUrlRef.current = url;
+        setAvatarObjectUrl(url);
+      } catch {
+        // no avatar
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, identity]);
+
+  // Revoke object URL on unmount.
+  useEffect(() => {
+    return () => {
+      if (avatarObjectUrlRef.current) {
+        URL.revokeObjectURL(avatarObjectUrlRef.current);
+      }
+    };
+  }, []);
 
   const handleCopyIdentity = useCallback(async () => {
     if (!identity) return;
@@ -402,6 +486,70 @@ export default function SettingsPopup({
       /* clipboard unavailable */
     }
   }, [identity]);
+
+  const handleCopyWorkspaceId = useCallback(async () => {
+    if (!groupId) return;
+    try {
+      await navigator.clipboard.writeText(groupId);
+      setCopiedWorkspace(true);
+      setTimeout(() => setCopiedWorkspace(false), 1500);
+    } catch {
+      /* clipboard unavailable */
+    }
+  }, [groupId]);
+
+  const handleAvatarChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      // Reset input so the same file can trigger onChange again later.
+      e.target.value = "";
+
+      setUploading(true);
+      try {
+        const uploadRes = await uploadBlobDirect(file);
+        if (!uploadRes.data?.blobId) {
+          addToast({ title: "Avatar", message: "Upload failed", type: "channel", duration: 3000 });
+          return;
+        }
+        const blobId = uploadRes.data.blobId;
+
+        // Show the new image immediately.
+        const newUrl = URL.createObjectURL(file);
+        if (avatarObjectUrlRef.current) URL.revokeObjectURL(avatarObjectUrlRef.current);
+        avatarObjectUrlRef.current = newUrl;
+        setAvatarObjectUrl(newUrl);
+
+        // Propagate to every channel/DM context the user is a member of.
+        const contextsRes = await new GroupApiDataSource().listGroupContexts(groupId);
+        if (contextsRes.data) {
+          const clientDs = new ClientApiDataSource();
+          for (const ctx of contextsRes.data) {
+            try {
+              const owned = await getMeroJs().admin.getContextIdentitiesOwned(ctx.contextId);
+              const executorKey = owned.identities?.[0];
+              if (!executorKey) continue;
+              const profilesRes = await clientDs.getProfiles(ctx.contextId, executorKey);
+              const myProfile = profilesRes.data?.find((p) => p.identity === executorKey);
+              await clientDs.updateProfile(
+                ctx.contextId,
+                executorKey,
+                myProfile?.username || username,
+                blobId,
+              );
+            } catch {
+              // best-effort per context
+            }
+          }
+        }
+
+        addToast({ title: "Avatar updated", message: "Your profile picture has been saved.", type: "channel", duration: 3000 });
+      } finally {
+        setUploading(false);
+      }
+    },
+    [addToast, groupId, username],
+  );
 
   // ── Session handlers ────────────────────────────────────────────────────────
 
@@ -474,7 +622,40 @@ export default function SettingsPopup({
 
       {/* Profile */}
       <ProfileCard>
-        <ProfileAvatar>{avatarInitial}</ProfileAvatar>
+        <ProfileAvatar
+          $hasImage={!!avatarObjectUrl}
+          onClick={() => !uploading && avatarInputRef.current?.click()}
+          title="Change profile picture"
+        >
+          {avatarObjectUrl ? (
+            <img
+              src={avatarObjectUrl}
+              alt="avatar"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            />
+          ) : (
+            avatarInitial
+          )}
+          <AvatarOverlay className="avatar-overlay">
+            {uploading ? (
+              <SpinnerSvg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+              </SpinnerSvg>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />
+                <circle cx="12" cy="13" r="4" />
+              </svg>
+            )}
+          </AvatarOverlay>
+          <input
+            ref={avatarInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={handleAvatarChange}
+          />
+        </ProfileAvatar>
         <ProfileInfo>
           <ProfileLabel>Profile</ProfileLabel>
           {username && <ProfileUsername>{username}</ProfileUsername>}
@@ -502,7 +683,25 @@ export default function SettingsPopup({
       <WorkspaceCard>
         <WorkspaceInfo>
           <WorkspaceLabel>Workspace</WorkspaceLabel>
-          <WorkspaceName>{namespaceName}</WorkspaceName>
+          {alias ? (
+            <WorkspaceName>{alias}</WorkspaceName>
+          ) : (
+            <WorkspaceIdRow>
+              <WorkspaceIdText title={groupId}>{groupId}</WorkspaceIdText>
+              <CopyButton onClick={handleCopyWorkspaceId} aria-label="Copy workspace ID">
+                {copiedWorkspace ? (
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#a5ff11" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                ) : (
+                  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                )}
+              </CopyButton>
+            </WorkspaceIdRow>
+          )}
         </WorkspaceInfo>
         <RoleBadge $admin={isAdmin} $mod={isModerator}>{isAdmin ? "Admin" : isModerator ? "Moderator" : "Member"}</RoleBadge>
       </WorkspaceCard>
@@ -538,7 +737,6 @@ export default function SettingsPopup({
       )}
 
       <LogoutSection>
-        <LogoutLabel>Session</LogoutLabel>
         <SessionActions>
           <ChangeWorkspaceButton onClick={handleChangeWorkspace}>
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">

--- a/app/src/components/popups/SettingsPopup.tsx
+++ b/app/src/components/popups/SettingsPopup.tsx
@@ -19,6 +19,7 @@ import { GroupApiDataSource, uploadBlobDirect } from "../../api/dataSource/group
 import { ClientApiDataSource } from "../../api/dataSource/clientApiDataSource";
 import { downloadBlob, getMeroJs } from "../../api/meroJsClient";
 import { useToast } from "../../contexts/ToastContext";
+import { invalidateAvatarCache } from "../../hooks/useAvatarUrl";
 // ─── Animations ────────────────────────────────────────────────────────────────
 
 const fadeIn = keyframes`
@@ -543,6 +544,7 @@ export default function SettingsPopup({
           }
         }
 
+        invalidateAvatarCache();
         addToast({ title: "Avatar updated", message: "Your profile picture has been saved.", type: "channel", duration: 3000 });
       } finally {
         setUploading(false);

--- a/app/src/components/settings/MemberDetails.tsx
+++ b/app/src/components/settings/MemberDetails.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useState } from "react";
 import styled from "styled-components";
 import type { User } from "../../types/Common";
-import { Avatar, Button, Input } from "@calimero-network/mero-ui";
+import { Button, Input } from "@calimero-network/mero-ui";
+import { IdentityAvatar } from "../IdentityAvatar";
 import type { Role, UserId } from "../../api/clientApi";
 import { ClientApiDataSource } from "../../api/dataSource/clientApiDataSource";
 import BaseModal from "../common/popups/BaseModal";
@@ -581,7 +582,7 @@ const MemberDetails: React.FC<MemberDetailsProps> = (props) => {
             return (
               <HoverRow key={identity}>
                 <UserInfo>
-                  <Avatar size="xs" name={username ?? ""} />
+                  <IdentityAvatar size="xs" identity={identity} contextId={props.contextId} name={username ?? ""} />
                   <Text $isSelected={optionsOpen === id}>
                     {username}
                   </Text>

--- a/app/src/components/sideSelector/UserItem.test.tsx
+++ b/app/src/components/sideSelector/UserItem.test.tsx
@@ -6,6 +6,10 @@ vi.mock("@calimero-network/mero-ui", () => ({
   Avatar: ({ name }: { name: string }) => <div>{name}</div>,
 }));
 
+vi.mock("../IdentityAvatar", () => ({
+  IdentityAvatar: ({ name }: { name: string }) => <div>{name}</div>,
+}));
+
 vi.mock("../popups/ConfirmPopup", () => ({
   default: ({
     toggle,

--- a/app/src/components/sideSelector/UserItem.tsx
+++ b/app/src/components/sideSelector/UserItem.tsx
@@ -1,7 +1,7 @@
 import { useCallback, memo, useState } from "react";
 import { styled } from "styled-components";
-import { Avatar } from "@calimero-network/mero-ui";
 import type { DMContextInfo } from "../../hooks/useDMs";
+import { IdentityAvatar } from "../IdentityAvatar";
 import ConfirmPopup from "../popups/ConfirmPopup";
 import { getDmDisplayName } from "../../utils/dmContext";
 import type { ContextUnread } from "../../hooks/useUnreadCounts";
@@ -121,11 +121,11 @@ function UserItem({
       $hasUnread={showBadge}
     >
       {isCollapsed ? (
-        <Avatar size="xs" name={displayName} />
+        <IdentityAvatar size="xs" identity={dm.otherIdentity} contextId={dm.contextId} name={displayName} />
       ) : (
         <>
           <UserInfoContainer>
-            <Avatar size="xs" name={displayName} />
+            <IdentityAvatar size="xs" identity={dm.otherIdentity} contextId={dm.contextId} name={displayName} />
             <NameContainer>{displayName}</NameContainer>
           </UserInfoContainer>
           <ActionsContainer>

--- a/app/src/components/virtualized-chat/Message/index.tsx
+++ b/app/src/components/virtualized-chat/Message/index.tsx
@@ -10,6 +10,7 @@ import { downloadBlob } from "../../../api/meroJsClient";
 
 import { POPUP_POSITION_SWITCH_HEIGHT } from "./AutocompleteList";
 import { Avatar } from "./Avatar";
+import { IdentityAvatar } from "../../IdentityAvatar";
 import DeletedMessage from "./DeletedMessage";
 import MessageSendingIcon from "./Icons/MessageSendingIcon";
 import MessageSentIcon from "./Icons/MessageSentIcon";
@@ -576,7 +577,7 @@ const Message = (props: MessageProps) => {
         {showHeader && (
           <SenderInfoContainer>
             <ProfileIconContainerMsg>
-              <Avatar size="sm" name={props.message.senderUsername} />
+              <IdentityAvatar size="sm" identity={props.message.sender} contextId={props.contextId} name={props.message.senderUsername} />
             </ProfileIconContainerMsg>
             <NameContainerSender>
               {props.message.senderUsername}

--- a/app/src/components/virtualized-chat/Message/index.tsx
+++ b/app/src/components/virtualized-chat/Message/index.tsx
@@ -9,7 +9,6 @@ import { formatTimeAgo } from "../utils";
 import { downloadBlob } from "../../../api/meroJsClient";
 
 import { POPUP_POSITION_SWITCH_HEIGHT } from "./AutocompleteList";
-import { Avatar } from "./Avatar";
 import { IdentityAvatar } from "../../IdentityAvatar";
 import DeletedMessage from "./DeletedMessage";
 import MessageSendingIcon from "./Icons/MessageSendingIcon";

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -27,22 +27,14 @@ function getProfilesForCtx(contextId: string): Promise<ProfileRow[]> {
 
   const executorKey = getContextIdentity() ?? "";
   if (!executorKey) {
-    // Not authenticated — do NOT cache, retry on next mount / version bump.
-    console.warn("[useAvatarUrl] getContextIdentity() is empty, skipping profile fetch");
     return Promise.resolve([]);
   }
 
-  console.log(`[useAvatarUrl] fetching profiles for context ${contextId} as ${executorKey}`);
-
   const p = new ClientApiDataSource()
     .getProfiles(contextId, executorKey)
-    .then((res) => {
-      console.log(`[useAvatarUrl] getProfiles returned ${res.data?.length ?? 0} profiles`, res.data);
-      return (res.data ?? []) as ProfileRow[];
-    })
+    .then((res) => (res.data ?? []) as ProfileRow[])
     .catch((err) => {
       console.error("[useAvatarUrl] getProfiles failed", err);
-      // Remove from cache so we can retry later.
       profilesForCtx.delete(contextId);
       return [] as ProfileRow[];
     });
@@ -55,13 +47,10 @@ async function resolveBlob(blobId: string, contextId: string): Promise<string | 
   if (blobUrlCache.has(blobId)) return blobUrlCache.get(blobId);
   if (blobFetchInFlight.has(blobId)) return blobFetchInFlight.get(blobId)!;
 
-  console.log(`[useAvatarUrl] downloading blob ${blobId} for context ${contextId}`);
-
   const p = downloadBlob(blobId, contextId)
     .then((blob) => {
       const url = URL.createObjectURL(blob);
       blobUrlCache.set(blobId, url);
-      console.log(`[useAvatarUrl] blob ${blobId} resolved to object URL`);
       return url;
     })
     .catch((err): undefined => {
@@ -101,10 +90,7 @@ export function useAvatarUrl(
       if (cancelled) return;
 
       const avatarBlobId = profiles.find((p) => p.identity === identity)?.avatar;
-      if (!avatarBlobId) {
-        console.log(`[useAvatarUrl] no avatar blob for identity ${identity} in context ${contextId}`);
-        return;
-      }
+      if (!avatarBlobId) return;
 
       const resolved = await resolveBlob(avatarBlobId, contextId);
       if (!cancelled && resolved) setUrl(resolved);

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -1,0 +1,128 @@
+import { useState, useEffect } from "react";
+import {
+  getContextIdentity,
+} from "@calimero-network/mero-react";
+import { ClientApiDataSource } from "../api/dataSource/clientApiDataSource";
+import { downloadBlob } from "../api/meroJsClient";
+
+type ProfileEntry = { avatarBlobId?: string };
+
+// Module-level caches survive re-renders and are shared across all hook instances.
+const profilesByContext = new Map<string, Map<string, ProfileEntry>>();
+const profileFetchInFlight = new Map<string, Promise<void>>();
+const blobUrlByBlobId = new Map<string, string>();
+const blobFetchInFlight = new Map<string, Promise<string | undefined>>();
+// key: `${contextId}:${identity}` → listeners to notify when URL becomes available
+const pendingListeners = new Map<string, Set<() => void>>();
+
+function notifyForContext(contextId: string) {
+  for (const [key, fns] of pendingListeners) {
+    if (key.startsWith(`${contextId}:`)) fns.forEach((fn) => fn());
+  }
+}
+
+async function ensureProfilesLoaded(contextId: string): Promise<void> {
+  if (profilesByContext.has(contextId)) return;
+  if (profileFetchInFlight.has(contextId)) {
+    await profileFetchInFlight.get(contextId)!;
+    return;
+  }
+  const executorKey = getContextIdentity() ?? "";
+  const api = new ClientApiDataSource();
+  const promise = api
+    .getProfiles(contextId, executorKey)
+    .then((res) => {
+      const map = new Map<string, ProfileEntry>();
+      for (const p of res.data ?? []) {
+        if (p.identity) map.set(p.identity, { avatarBlobId: p.avatar ?? undefined });
+      }
+      profilesByContext.set(contextId, map);
+    })
+    .catch(() => {
+      // On error leave the cache empty so we don't retry spam, but remove
+      // the in-flight entry so it can be retried later.
+    })
+    .finally(() => {
+      profileFetchInFlight.delete(contextId);
+      notifyForContext(contextId);
+    });
+  profileFetchInFlight.set(contextId, promise);
+  await promise;
+}
+
+async function resolveAvatarUrl(
+  blobId: string,
+  contextId: string,
+): Promise<string | undefined> {
+  if (blobUrlByBlobId.has(blobId)) return blobUrlByBlobId.get(blobId);
+  if (blobFetchInFlight.has(blobId)) return blobFetchInFlight.get(blobId)!;
+
+  const promise = downloadBlob(blobId, contextId)
+    .then((blob) => {
+      const url = URL.createObjectURL(blob);
+      blobUrlByBlobId.set(blobId, url);
+      return url;
+    })
+    .catch(() => undefined)
+    .finally(() => blobFetchInFlight.delete(blobId));
+
+  blobFetchInFlight.set(blobId, promise);
+  return promise;
+}
+
+/** Returns the object URL for an identity's avatar, or undefined while loading / if none set. */
+export function useAvatarUrl(
+  identity: string | undefined,
+  contextId: string | undefined,
+): string | undefined {
+  const cacheKey =
+    identity && contextId ? `${contextId}:${identity}` : undefined;
+
+  const [url, setUrl] = useState<string | undefined>(() => {
+    if (!identity || !contextId) return undefined;
+    const blobId = profilesByContext.get(contextId)?.get(identity)?.avatarBlobId;
+    return blobId ? blobUrlByBlobId.get(blobId) : undefined;
+  });
+
+  useEffect(() => {
+    if (!identity || !contextId || !cacheKey) return;
+
+    let cancelled = false;
+
+    const tryResolve = () => {
+      if (cancelled) return;
+      const blobId = profilesByContext.get(contextId)?.get(identity)?.avatarBlobId;
+      if (!blobId) return;
+      if (blobUrlByBlobId.has(blobId)) {
+        setUrl(blobUrlByBlobId.get(blobId));
+        return;
+      }
+      resolveAvatarUrl(blobId, contextId).then((resolved) => {
+        if (!cancelled) setUrl(resolved ?? undefined);
+      });
+    };
+
+    if (!pendingListeners.has(cacheKey)) pendingListeners.set(cacheKey, new Set());
+    pendingListeners.get(cacheKey)!.add(tryResolve);
+
+    ensureProfilesLoaded(contextId).then(tryResolve);
+
+    return () => {
+      cancelled = true;
+      pendingListeners.get(cacheKey)?.delete(tryResolve);
+    };
+  }, [identity, contextId, cacheKey]);
+
+  return url;
+}
+
+/** Evict all cached profiles for a context so the next load re-fetches fresh data.
+ *  Call after the local user updates their own avatar. */
+export function invalidateAvatarCache(contextId?: string) {
+  if (contextId) {
+    profilesByContext.delete(contextId);
+  } else {
+    profilesByContext.clear();
+    blobUrlByBlobId.clear();
+  }
+}

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -1,19 +1,21 @@
-import { useState, useEffect } from "react";
-import {
-  getContextIdentity,
-} from "@calimero-network/mero-react";
+import { useState, useEffect, useCallback } from "react";
+import { getContextIdentity } from "@calimero-network/mero-react";
 import { ClientApiDataSource } from "../api/dataSource/clientApiDataSource";
 import { downloadBlob } from "../api/meroJsClient";
 
 type ProfileEntry = { avatarBlobId?: string };
 
-// Module-level caches survive re-renders and are shared across all hook instances.
+// ── Module-level caches (shared across all hook instances) ───────────────────
+
 const profilesByContext = new Map<string, Map<string, ProfileEntry>>();
 const profileFetchInFlight = new Map<string, Promise<void>>();
 const blobUrlByBlobId = new Map<string, string>();
 const blobFetchInFlight = new Map<string, Promise<string | undefined>>();
-// key: `${contextId}:${identity}` → listeners to notify when URL becomes available
-const pendingListeners = new Map<string, Set<() => void>>();
+
+// Global version bump — all mounted hooks subscribe; when this increments they
+// re-run their effects and re-fetch profiles from scratch.
+let cacheVersion = 0;
+const cacheVersionListeners = new Set<() => void>();
 
 function notifyForContext(contextId: string) {
   for (const [key, fns] of pendingListeners) {
@@ -21,13 +23,21 @@ function notifyForContext(contextId: string) {
   }
 }
 
+// key: `${contextId}:${identity}` — notified once profiles for a context land
+const pendingListeners = new Map<string, Set<() => void>>();
+
+// ── Async helpers ─────────────────────────────────────────────────────────────
+
 async function ensureProfilesLoaded(contextId: string): Promise<void> {
   if (profilesByContext.has(contextId)) return;
   if (profileFetchInFlight.has(contextId)) {
     await profileFetchInFlight.get(contextId)!;
     return;
   }
+
   const executorKey = getContextIdentity() ?? "";
+  if (!executorKey) return; // not authenticated yet — skip
+
   const api = new ClientApiDataSource();
   const promise = api
     .getProfiles(contextId, executorKey)
@@ -39,13 +49,13 @@ async function ensureProfilesLoaded(contextId: string): Promise<void> {
       profilesByContext.set(contextId, map);
     })
     .catch(() => {
-      // On error leave the cache empty so we don't retry spam, but remove
-      // the in-flight entry so it can be retried later.
+      /* silent — effect will retry on next version bump or re-mount */
     })
     .finally(() => {
       profileFetchInFlight.delete(contextId);
       notifyForContext(contextId);
     });
+
   profileFetchInFlight.set(contextId, promise);
   await promise;
 }
@@ -70,13 +80,14 @@ async function resolveAvatarUrl(
   return promise;
 }
 
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
 /** Returns the object URL for an identity's avatar, or undefined while loading / if none set. */
 export function useAvatarUrl(
   identity: string | undefined,
   contextId: string | undefined,
 ): string | undefined {
-  const cacheKey =
-    identity && contextId ? `${contextId}:${identity}` : undefined;
+  const cacheKey = identity && contextId ? `${contextId}:${identity}` : undefined;
 
   const [url, setUrl] = useState<string | undefined>(() => {
     if (!identity || !contextId) return undefined;
@@ -84,45 +95,64 @@ export function useAvatarUrl(
     return blobId ? blobUrlByBlobId.get(blobId) : undefined;
   });
 
+  // Mirror the global version so version bumps from invalidateAvatarCache
+  // re-run the fetch effect below.
+  const [version, setVersion] = useState(cacheVersion);
   useEffect(() => {
-    if (!identity || !contextId || !cacheKey) return;
+    const bump = () => setVersion((v) => v + 1);
+    cacheVersionListeners.add(bump);
+    return () => { cacheVersionListeners.delete(bump); };
+  }, []);
 
-    let cancelled = false;
-
-    const tryResolve = () => {
-      if (cancelled) return;
+  const tryResolve = useCallback(
+    (cancelled: { value: boolean }) => {
+      if (cancelled.value || !identity || !contextId) return;
       const blobId = profilesByContext.get(contextId)?.get(identity)?.avatarBlobId;
-      if (!blobId) return;
+      if (!blobId) {
+        setUrl(undefined);
+        return;
+      }
       if (blobUrlByBlobId.has(blobId)) {
         setUrl(blobUrlByBlobId.get(blobId));
         return;
       }
       resolveAvatarUrl(blobId, contextId).then((resolved) => {
-        if (!cancelled) setUrl(resolved ?? undefined);
+        if (!cancelled.value) setUrl(resolved ?? undefined);
       });
-    };
+    },
+    [identity, contextId],
+  );
 
+  useEffect(() => {
+    if (!identity || !contextId || !cacheKey) return;
+
+    const cancelled = { value: false };
+
+    const listener = () => tryResolve(cancelled);
     if (!pendingListeners.has(cacheKey)) pendingListeners.set(cacheKey, new Set());
-    pendingListeners.get(cacheKey)!.add(tryResolve);
+    pendingListeners.get(cacheKey)!.add(listener);
 
-    ensureProfilesLoaded(contextId).then(tryResolve);
+    ensureProfilesLoaded(contextId).then(() => tryResolve(cancelled));
 
     return () => {
-      cancelled = true;
-      pendingListeners.get(cacheKey)?.delete(tryResolve);
+      cancelled.value = true;
+      pendingListeners.get(cacheKey)?.delete(listener);
     };
-  }, [identity, contextId, cacheKey]);
+    // version is intentionally included: a cache invalidation bumps this and
+    // forces the effect to re-run + re-fetch profiles.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [identity, contextId, cacheKey, version]);
 
   return url;
 }
 
-/** Evict all cached profiles for a context so the next load re-fetches fresh data.
+// ── Cache control ─────────────────────────────────────────────────────────────
+
+/** Evict cached profiles and notify all mounted hooks to re-fetch.
  *  Call after the local user updates their own avatar. */
-export function invalidateAvatarCache(contextId?: string) {
-  if (contextId) {
-    profilesByContext.delete(contextId);
-  } else {
-    profilesByContext.clear();
-    blobUrlByBlobId.clear();
-  }
+export function invalidateAvatarCache() {
+  profilesByContext.clear();
+  blobUrlByBlobId.clear();
+  cacheVersion++;
+  cacheVersionListeners.forEach((fn) => fn());
 }

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -17,7 +17,7 @@ const blobFetchInFlight = new Map<string, Promise<string | undefined>>();
 
 // Version counter — incremented by invalidateAvatarCache so all mounted hooks
 // re-run their effects after a user updates their avatar.
-let cacheVersion = 0;
+let _cacheVersion = 0;
 const cacheVersionListeners = new Set<() => void>();
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -97,7 +97,6 @@ export function useAvatarUrl(
     })();
 
     return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [identity, contextId, version]);
 
   return url;
@@ -110,6 +109,6 @@ export function useAvatarUrl(
 export function invalidateAvatarCache() {
   profilesForCtx.clear();
   blobUrlCache.clear();
-  cacheVersion++;
+  _cacheVersion++;
   cacheVersionListeners.forEach((fn) => fn());
 }

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -15,9 +15,6 @@ const profilesForCtx = new Map<string, Promise<ProfileRow[]>>();
 const blobUrlCache = new Map<string, string>();
 const blobFetchInFlight = new Map<string, Promise<string | undefined>>();
 
-// Version counter — incremented by invalidateAvatarCache so all mounted hooks
-// re-run their effects after a user updates their avatar.
-let _cacheVersion = 0;
 const cacheVersionListeners = new Set<() => void>();
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -125,6 +122,5 @@ export function invalidateAvatarCache() {
   profilesForCtx.clear();
   blobUrlCache.forEach((url) => URL.revokeObjectURL(url));
   blobUrlCache.clear();
-  _cacheVersion++;
   cacheVersionListeners.forEach((fn) => fn());
 }

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { getContextIdentity } from "@calimero-network/mero-react";
+import { getContextId, getContextIdentity } from "@calimero-network/mero-react";
+import { getMeroJs, downloadBlob } from "../api/meroJsClient";
 import { ClientApiDataSource } from "../api/dataSource/clientApiDataSource";
-import { downloadBlob } from "../api/meroJsClient";
 
 // ── Module-level caches ───────────────────────────────────────────────────────
 
@@ -22,22 +22,34 @@ const cacheVersionListeners = new Set<() => void>();
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+async function resolveExecutorKey(contextId: string): Promise<string> {
+  // Use the active context's identity directly — no extra RPC needed.
+  if (contextId === (getContextId() ?? "")) {
+    return getContextIdentity() ?? "";
+  }
+  // For other contexts (e.g. DM contexts), look up the owned identity.
+  try {
+    const owned = await getMeroJs().admin.getContextIdentitiesOwned(contextId);
+    return (owned as { identities?: string[] }).identities?.[0] ?? "";
+  } catch {
+    return getContextIdentity() ?? "";
+  }
+}
+
 function getProfilesForCtx(contextId: string): Promise<ProfileRow[]> {
   if (profilesForCtx.has(contextId)) return profilesForCtx.get(contextId)!;
 
-  const executorKey = getContextIdentity() ?? "";
-  if (!executorKey) {
-    return Promise.resolve([]);
-  }
-
-  const p = new ClientApiDataSource()
-    .getProfiles(contextId, executorKey)
-    .then((res) => (res.data ?? []) as ProfileRow[])
-    .catch((err) => {
-      console.error("[useAvatarUrl] getProfiles failed", err);
-      profilesForCtx.delete(contextId);
-      return [] as ProfileRow[];
-    });
+  const p = resolveExecutorKey(contextId).then((executorKey) => {
+    if (!executorKey) return [] as ProfileRow[];
+    return new ClientApiDataSource()
+      .getProfiles(contextId, executorKey)
+      .then((res) => (res.data ?? []) as ProfileRow[])
+      .catch((err) => {
+        console.error("[useAvatarUrl] getProfiles failed", err);
+        profilesForCtx.delete(contextId);
+        return [] as ProfileRow[];
+      });
+  });
 
   profilesForCtx.set(contextId, p);
   return p;
@@ -111,6 +123,7 @@ export function useAvatarUrl(
  *  Call immediately after the user updates their avatar. */
 export function invalidateAvatarCache() {
   profilesForCtx.clear();
+  blobUrlCache.forEach((url) => URL.revokeObjectURL(url));
   blobUrlCache.clear();
   _cacheVersion++;
   cacheVersionListeners.forEach((fn) => fn());

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -94,6 +94,10 @@ export function useAvatarUrl(
     if (!identity || !contextId) return;
     let cancelled = false;
 
+    // Clear immediately so a revoked/stale URL doesn't linger while we re-fetch.
+    // Avatar falls back to initials during the async window.
+    setUrl(undefined);
+
     (async () => {
       const profiles = await getProfilesForCtx(contextId);
       if (cancelled) return;

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -90,10 +90,13 @@ export function useAvatarUrl(
       if (cancelled) return;
 
       const avatarBlobId = profiles.find((p) => p.identity === identity)?.avatar;
-      if (!avatarBlobId) return;
+      if (!avatarBlobId) {
+        setUrl(undefined);
+        return;
+      }
 
       const resolved = await resolveBlob(avatarBlobId, contextId);
-      if (!cancelled && resolved) setUrl(resolved);
+      if (!cancelled) setUrl(resolved);
     })();
 
     return () => { cancelled = true; };

--- a/app/src/hooks/useAvatarUrl.ts
+++ b/app/src/hooks/useAvatarUrl.ts
@@ -1,158 +1,129 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { getContextIdentity } from "@calimero-network/mero-react";
 import { ClientApiDataSource } from "../api/dataSource/clientApiDataSource";
 import { downloadBlob } from "../api/meroJsClient";
 
-type ProfileEntry = { avatarBlobId?: string };
+// ── Module-level caches ───────────────────────────────────────────────────────
 
-// ── Module-level caches (shared across all hook instances) ───────────────────
+type ProfileRow = { identity: string; avatar?: string };
 
-const profilesByContext = new Map<string, Map<string, ProfileEntry>>();
-const profileFetchInFlight = new Map<string, Promise<void>>();
-const blobUrlByBlobId = new Map<string, string>();
+// Unified cache + in-flight dedup: once the promise resolves it stays here so
+// future awaits return the already-resolved value immediately.
+const profilesForCtx = new Map<string, Promise<ProfileRow[]>>();
+
+// blob ID → object URL
+const blobUrlCache = new Map<string, string>();
 const blobFetchInFlight = new Map<string, Promise<string | undefined>>();
 
-// Global version bump — all mounted hooks subscribe; when this increments they
-// re-run their effects and re-fetch profiles from scratch.
+// Version counter — incremented by invalidateAvatarCache so all mounted hooks
+// re-run their effects after a user updates their avatar.
 let cacheVersion = 0;
 const cacheVersionListeners = new Set<() => void>();
 
-function notifyForContext(contextId: string) {
-  for (const [key, fns] of pendingListeners) {
-    if (key.startsWith(`${contextId}:`)) fns.forEach((fn) => fn());
-  }
-}
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-// key: `${contextId}:${identity}` — notified once profiles for a context land
-const pendingListeners = new Map<string, Set<() => void>>();
-
-// ── Async helpers ─────────────────────────────────────────────────────────────
-
-async function ensureProfilesLoaded(contextId: string): Promise<void> {
-  if (profilesByContext.has(contextId)) return;
-  if (profileFetchInFlight.has(contextId)) {
-    await profileFetchInFlight.get(contextId)!;
-    return;
-  }
+function getProfilesForCtx(contextId: string): Promise<ProfileRow[]> {
+  if (profilesForCtx.has(contextId)) return profilesForCtx.get(contextId)!;
 
   const executorKey = getContextIdentity() ?? "";
-  if (!executorKey) return; // not authenticated yet — skip
+  if (!executorKey) {
+    // Not authenticated — do NOT cache, retry on next mount / version bump.
+    console.warn("[useAvatarUrl] getContextIdentity() is empty, skipping profile fetch");
+    return Promise.resolve([]);
+  }
 
-  const api = new ClientApiDataSource();
-  const promise = api
+  console.log(`[useAvatarUrl] fetching profiles for context ${contextId} as ${executorKey}`);
+
+  const p = new ClientApiDataSource()
     .getProfiles(contextId, executorKey)
     .then((res) => {
-      const map = new Map<string, ProfileEntry>();
-      for (const p of res.data ?? []) {
-        if (p.identity) map.set(p.identity, { avatarBlobId: p.avatar ?? undefined });
-      }
-      profilesByContext.set(contextId, map);
+      console.log(`[useAvatarUrl] getProfiles returned ${res.data?.length ?? 0} profiles`, res.data);
+      return (res.data ?? []) as ProfileRow[];
     })
-    .catch(() => {
-      /* silent — effect will retry on next version bump or re-mount */
-    })
-    .finally(() => {
-      profileFetchInFlight.delete(contextId);
-      notifyForContext(contextId);
+    .catch((err) => {
+      console.error("[useAvatarUrl] getProfiles failed", err);
+      // Remove from cache so we can retry later.
+      profilesForCtx.delete(contextId);
+      return [] as ProfileRow[];
     });
 
-  profileFetchInFlight.set(contextId, promise);
-  await promise;
+  profilesForCtx.set(contextId, p);
+  return p;
 }
 
-async function resolveAvatarUrl(
-  blobId: string,
-  contextId: string,
-): Promise<string | undefined> {
-  if (blobUrlByBlobId.has(blobId)) return blobUrlByBlobId.get(blobId);
+async function resolveBlob(blobId: string, contextId: string): Promise<string | undefined> {
+  if (blobUrlCache.has(blobId)) return blobUrlCache.get(blobId);
   if (blobFetchInFlight.has(blobId)) return blobFetchInFlight.get(blobId)!;
 
-  const promise = downloadBlob(blobId, contextId)
+  console.log(`[useAvatarUrl] downloading blob ${blobId} for context ${contextId}`);
+
+  const p = downloadBlob(blobId, contextId)
     .then((blob) => {
       const url = URL.createObjectURL(blob);
-      blobUrlByBlobId.set(blobId, url);
+      blobUrlCache.set(blobId, url);
+      console.log(`[useAvatarUrl] blob ${blobId} resolved to object URL`);
       return url;
     })
-    .catch(() => undefined)
+    .catch((err): undefined => {
+      console.error(`[useAvatarUrl] downloadBlob failed for ${blobId}`, err);
+      return undefined;
+    })
     .finally(() => blobFetchInFlight.delete(blobId));
 
-  blobFetchInFlight.set(blobId, promise);
-  return promise;
+  blobFetchInFlight.set(blobId, p);
+  return p;
 }
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
-/** Returns the object URL for an identity's avatar, or undefined while loading / if none set. */
+/** Async-loads the avatar image URL for an identity within a context.
+ *  Returns undefined while loading or when no avatar is set. */
 export function useAvatarUrl(
   identity: string | undefined,
   contextId: string | undefined,
 ): string | undefined {
-  const cacheKey = identity && contextId ? `${contextId}:${identity}` : undefined;
+  const [url, setUrl] = useState<string | undefined>(undefined);
+  const [version, setVersion] = useState(0);
 
-  const [url, setUrl] = useState<string | undefined>(() => {
-    if (!identity || !contextId) return undefined;
-    const blobId = profilesByContext.get(contextId)?.get(identity)?.avatarBlobId;
-    return blobId ? blobUrlByBlobId.get(blobId) : undefined;
-  });
-
-  // Mirror the global version so version bumps from invalidateAvatarCache
-  // re-run the fetch effect below.
-  const [version, setVersion] = useState(cacheVersion);
+  // Subscribe to cache invalidation so we re-fetch after avatar updates.
   useEffect(() => {
     const bump = () => setVersion((v) => v + 1);
     cacheVersionListeners.add(bump);
     return () => { cacheVersionListeners.delete(bump); };
   }, []);
 
-  const tryResolve = useCallback(
-    (cancelled: { value: boolean }) => {
-      if (cancelled.value || !identity || !contextId) return;
-      const blobId = profilesByContext.get(contextId)?.get(identity)?.avatarBlobId;
-      if (!blobId) {
-        setUrl(undefined);
-        return;
-      }
-      if (blobUrlByBlobId.has(blobId)) {
-        setUrl(blobUrlByBlobId.get(blobId));
-        return;
-      }
-      resolveAvatarUrl(blobId, contextId).then((resolved) => {
-        if (!cancelled.value) setUrl(resolved ?? undefined);
-      });
-    },
-    [identity, contextId],
-  );
-
   useEffect(() => {
-    if (!identity || !contextId || !cacheKey) return;
+    if (!identity || !contextId) return;
+    let cancelled = false;
 
-    const cancelled = { value: false };
+    (async () => {
+      const profiles = await getProfilesForCtx(contextId);
+      if (cancelled) return;
 
-    const listener = () => tryResolve(cancelled);
-    if (!pendingListeners.has(cacheKey)) pendingListeners.set(cacheKey, new Set());
-    pendingListeners.get(cacheKey)!.add(listener);
+      const avatarBlobId = profiles.find((p) => p.identity === identity)?.avatar;
+      if (!avatarBlobId) {
+        console.log(`[useAvatarUrl] no avatar blob for identity ${identity} in context ${contextId}`);
+        return;
+      }
 
-    ensureProfilesLoaded(contextId).then(() => tryResolve(cancelled));
+      const resolved = await resolveBlob(avatarBlobId, contextId);
+      if (!cancelled && resolved) setUrl(resolved);
+    })();
 
-    return () => {
-      cancelled.value = true;
-      pendingListeners.get(cacheKey)?.delete(listener);
-    };
-    // version is intentionally included: a cache invalidation bumps this and
-    // forces the effect to re-run + re-fetch profiles.
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identity, contextId, cacheKey, version]);
+  }, [identity, contextId, version]);
 
   return url;
 }
 
 // ── Cache control ─────────────────────────────────────────────────────────────
 
-/** Evict cached profiles and notify all mounted hooks to re-fetch.
- *  Call after the local user updates their own avatar. */
+/** Clear all profile + blob caches and force every mounted hook to re-fetch.
+ *  Call immediately after the user updates their avatar. */
 export function invalidateAvatarCache() {
-  profilesByContext.clear();
-  blobUrlByBlobId.clear();
+  profilesForCtx.clear();
+  blobUrlCache.clear();
   cacheVersion++;
   cacheVersionListeners.forEach((fn) => fn());
 }

--- a/app/src/hooks/useDraft.test.ts
+++ b/app/src/hooks/useDraft.test.ts
@@ -320,7 +320,7 @@ describe("useDraft — channel switch", () => {
     vi.useRealTimers();
   });
 
-  it("cancels pending debounced save when channel changes", async () => {
+  it("flushes pending debounced save immediately when channel changes", async () => {
     const { result, rerender } = renderHook(({ ch }) => useDraft(ch), {
       initialProps: { ch: "channel-a" },
     });
@@ -328,9 +328,14 @@ describe("useDraft — channel switch", () => {
 
     act(() => result.current.setDraft("unsaved text"));
     rerender({ ch: "channel-b" });
-    act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
 
-    expect(mockSaveDraft).not.toHaveBeenCalled();
+    // Flush happens synchronously in the cleanup — no need to advance timers.
+    expect(mockSaveDraft).toHaveBeenCalledWith(
+      "ctx-123",
+      "identity-abc",
+      "channel-a",
+      "unsaved text",
+    );
   });
 
   it("loads the new channel draft after switching", async () => {

--- a/app/src/hooks/useDraft.test.ts
+++ b/app/src/hooks/useDraft.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for useDraft
+ *
+ * Coverage:
+ *   - loads draft from WASM on mount / channel change
+ *   - hasDraft reflects whether draft is non-empty
+ *   - setDraft debounces WASM save by 4s
+ *   - setDraft("") calls deleteDraft immediately, skips debounce
+ *   - clearDraft calls deleteDraft immediately and resets state
+ *   - switching channels cancels any pending debounce for the old channel
+ *   - undefined channelName keeps draft empty, never calls API
+ *
+ * Run: pnpm exec vitest run src/hooks/useDraft.test.ts
+ */
+
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Hoisted mocks (available before vi.mock factories run) ────────────────────
+
+const { mockGetDraft, mockSaveDraft, mockDeleteDraft, mockGetContextId, mockGetContextIdentity } =
+  vi.hoisted(() => ({
+    mockGetDraft: vi.fn(),
+    mockSaveDraft: vi.fn(),
+    mockDeleteDraft: vi.fn(),
+    mockGetContextId: vi.fn(),
+    mockGetContextIdentity: vi.fn(),
+  }));
+
+vi.mock("../api/dataSource/clientApiDataSource", () => ({
+  ClientApiDataSource: class {
+    getDraft = mockGetDraft;
+    saveDraft = mockSaveDraft;
+    deleteDraft = mockDeleteDraft;
+  },
+}));
+
+vi.mock("@calimero-network/mero-react", () => ({
+  getContextId: mockGetContextId,
+  getContextIdentity: mockGetContextIdentity,
+}));
+
+import { useDraft } from "./useDraft";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const DEBOUNCE_MS = 4_000;
+
+/** Flush all pending promises so async useEffect bodies run to completion. */
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useDraft — load", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetContextId.mockReturnValue("ctx-123");
+    mockGetContextIdentity.mockReturnValue("identity-abc");
+    mockGetDraft.mockResolvedValue({ data: "" });
+    mockSaveDraft.mockResolvedValue({ data: undefined });
+    mockDeleteDraft.mockResolvedValue({ data: undefined });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls getDraft with contextId, executorPublicKey and channel on mount", async () => {
+    mockGetDraft.mockResolvedValue({ data: "hello world" });
+
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    expect(mockGetDraft).toHaveBeenCalledWith("ctx-123", "identity-abc", "general");
+    expect(result.current.draft).toBe("hello world");
+    expect(result.current.hasDraft).toBe(true);
+  });
+
+  it("starts with empty draft before the async load resolves", () => {
+    mockGetDraft.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { result } = renderHook(() => useDraft("general"));
+
+    expect(result.current.draft).toBe("");
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("hasDraft is false when persisted draft is empty string", async () => {
+    mockGetDraft.mockResolvedValue({ data: "" });
+
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    expect(result.current.hasDraft).toBe(false);
+    expect(result.current.draft).toBe("");
+  });
+
+  it("hasDraft is false when getDraft returns null data", async () => {
+    mockGetDraft.mockResolvedValue({ data: null });
+
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("reloads draft when channel changes", async () => {
+    mockGetDraft
+      .mockResolvedValueOnce({ data: "draft-a" })
+      .mockResolvedValueOnce({ data: "draft-b" });
+
+    const { result, rerender } = renderHook(({ ch }) => useDraft(ch), {
+      initialProps: { ch: "channel-a" },
+    });
+
+    await flushPromises();
+    expect(result.current.draft).toBe("draft-a");
+
+    rerender({ ch: "channel-b" });
+    await flushPromises();
+
+    expect(result.current.draft).toBe("draft-b");
+    expect(mockGetDraft).toHaveBeenCalledTimes(2);
+    expect(mockGetDraft).toHaveBeenLastCalledWith("ctx-123", "identity-abc", "channel-b");
+  });
+
+  it("does not call getDraft when channelName is undefined", async () => {
+    renderHook(() => useDraft(undefined));
+    await flushPromises();
+
+    expect(mockGetDraft).not.toHaveBeenCalled();
+  });
+
+  it("does not call getDraft when contextId is missing", async () => {
+    mockGetContextId.mockReturnValue(undefined);
+
+    renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    expect(mockGetDraft).not.toHaveBeenCalled();
+  });
+
+  it("resets draft to empty when channel becomes undefined", async () => {
+    mockGetDraft.mockResolvedValue({ data: "something" });
+
+    const { result, rerender } = renderHook(({ ch }) => useDraft(ch), {
+      initialProps: { ch: "general" as string | undefined },
+    });
+    await flushPromises();
+    expect(result.current.draft).toBe("something");
+
+    rerender({ ch: undefined });
+
+    expect(result.current.draft).toBe("");
+  });
+});
+
+describe("useDraft — setDraft debounce", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetContextId.mockReturnValue("ctx-123");
+    mockGetContextIdentity.mockReturnValue("identity-abc");
+    mockGetDraft.mockResolvedValue({ data: "" });
+    mockSaveDraft.mockResolvedValue({ data: undefined });
+    mockDeleteDraft.mockResolvedValue({ data: undefined });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("updates draft state immediately when setDraft is called", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("typed text"));
+
+    expect(result.current.draft).toBe("typed text");
+    expect(result.current.hasDraft).toBe(true);
+  });
+
+  it("does NOT call saveDraft before debounce window elapses", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("not saved yet"));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_MS - 1));
+
+    expect(mockSaveDraft).not.toHaveBeenCalled();
+  });
+
+  it("calls saveDraft after the full debounce window", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("save me"));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+
+    expect(mockSaveDraft).toHaveBeenCalledWith("ctx-123", "identity-abc", "general", "save me");
+  });
+
+  it("resets debounce on rapid keystrokes — saveDraft fires only once with final value", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("a"));
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => result.current.setDraft("ab"));
+    act(() => vi.advanceTimersByTime(1000));
+    act(() => result.current.setDraft("abc"));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+
+    expect(mockSaveDraft).toHaveBeenCalledTimes(1);
+    expect(mockSaveDraft).toHaveBeenCalledWith("ctx-123", "identity-abc", "general", "abc");
+  });
+
+  it("calls deleteDraft immediately when setDraft is called with empty string", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("some text"));
+    act(() => result.current.setDraft(""));
+
+    expect(mockDeleteDraft).toHaveBeenCalledWith("ctx-123", "identity-abc", "general");
+    expect(mockSaveDraft).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending debounce when field is cleared — saveDraft never fires", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("text"));
+    act(() => result.current.setDraft(""));
+    act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+
+    expect(mockSaveDraft).not.toHaveBeenCalled();
+  });
+
+  it("hasDraft reflects current text correctly", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    expect(result.current.hasDraft).toBe(false);
+    act(() => result.current.setDraft("text"));
+    expect(result.current.hasDraft).toBe(true);
+    act(() => result.current.setDraft(""));
+    expect(result.current.hasDraft).toBe(false);
+  });
+});
+
+describe("useDraft — clearDraft", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetContextId.mockReturnValue("ctx-123");
+    mockGetContextIdentity.mockReturnValue("identity-abc");
+    mockGetDraft.mockResolvedValue({ data: "" });
+    mockSaveDraft.mockResolvedValue({ data: undefined });
+    mockDeleteDraft.mockResolvedValue({ data: undefined });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resets draft state to empty", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("hello"));
+    act(() => result.current.clearDraft());
+
+    expect(result.current.draft).toBe("");
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("calls deleteDraft immediately", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("hello"));
+    act(() => result.current.clearDraft());
+
+    expect(mockDeleteDraft).toHaveBeenCalledWith("ctx-123", "identity-abc", "general");
+  });
+
+  it("cancels any pending debounced save — saveDraft must not fire", async () => {
+    const { result } = renderHook(() => useDraft("general"));
+    await flushPromises();
+
+    act(() => result.current.setDraft("draft text"));
+    act(() => result.current.clearDraft());
+    act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+
+    expect(mockSaveDraft).not.toHaveBeenCalled();
+    expect(mockDeleteDraft).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useDraft — channel switch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetContextId.mockReturnValue("ctx-123");
+    mockGetContextIdentity.mockReturnValue("identity-abc");
+    mockGetDraft.mockResolvedValue({ data: "" });
+    mockSaveDraft.mockResolvedValue({ data: undefined });
+    mockDeleteDraft.mockResolvedValue({ data: undefined });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancels pending debounced save when channel changes", async () => {
+    const { result, rerender } = renderHook(({ ch }) => useDraft(ch), {
+      initialProps: { ch: "channel-a" },
+    });
+    await flushPromises();
+
+    act(() => result.current.setDraft("unsaved text"));
+    rerender({ ch: "channel-b" });
+    act(() => vi.advanceTimersByTime(DEBOUNCE_MS));
+
+    expect(mockSaveDraft).not.toHaveBeenCalled();
+  });
+
+  it("loads the new channel draft after switching", async () => {
+    mockGetDraft
+      .mockResolvedValueOnce({ data: "draft-a" })
+      .mockResolvedValueOnce({ data: "draft-b" });
+
+    const { result, rerender } = renderHook(({ ch }) => useDraft(ch), {
+      initialProps: { ch: "channel-a" },
+    });
+    await flushPromises();
+    expect(result.current.draft).toBe("draft-a");
+
+    rerender({ ch: "channel-b" });
+    await flushPromises();
+
+    expect(result.current.draft).toBe("draft-b");
+  });
+
+  it("calls getDraft for each channel switch", async () => {
+    const { rerender } = renderHook(({ ch }) => useDraft(ch), {
+      initialProps: { ch: "channel-a" },
+    });
+    await flushPromises();
+
+    rerender({ ch: "channel-b" });
+    await flushPromises();
+
+    expect(mockGetDraft).toHaveBeenCalledTimes(2);
+    expect(mockGetDraft).toHaveBeenNthCalledWith(1, "ctx-123", "identity-abc", "channel-a");
+    expect(mockGetDraft).toHaveBeenNthCalledWith(2, "ctx-123", "identity-abc", "channel-b");
+  });
+});

--- a/app/src/hooks/useDraft.ts
+++ b/app/src/hooks/useDraft.ts
@@ -87,6 +87,7 @@ export function useDraft(channelName: string | undefined): {
       }
 
       debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
         persistDraft(channel, text);
       }, DEBOUNCE_MS);
     },

--- a/app/src/hooks/useDraft.ts
+++ b/app/src/hooks/useDraft.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getContextId, getContextIdentity } from "@calimero-network/mero-react";
 import { ClientApiDataSource } from "../api/dataSource/clientApiDataSource";
+import { emptyText } from "../utils/markdownParser";
 
 const DEBOUNCE_MS = 4_000;
 
@@ -22,19 +23,17 @@ export function useDraft(channelName: string | undefined): {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const channelRef = useRef(channelName);
   channelRef.current = channelName;
+  const pendingTextRef = useRef<string>("");
 
   // Load draft when channel changes.
   useEffect(() => {
-    if (!channelName) {
-      setDraftState("");
-      return;
-    }
+    // Immediately clear stale draft so hasDraft never reflects the previous channel.
+    setDraftState("");
+
+    if (!channelName) return;
     const contextId = getContextId();
     const executorPublicKey = getContextIdentity();
-    if (!contextId || !executorPublicKey) {
-      setDraftState("");
-      return;
-    }
+    if (!contextId || !executorPublicKey) return;
 
     let cancelled = false;
     (async () => {
@@ -45,10 +44,16 @@ export function useDraft(channelName: string | undefined): {
 
     return () => {
       cancelled = true;
-      // Flush any pending save for the channel we're leaving.
+      // Flush any pending save for the channel we're leaving before clearing the timer.
+      // Use `channelName` from the closure — channelRef.current is already the new value.
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
+        const ctx = getContextId();
+        const key = getContextIdentity();
+        if (ctx && key && channelName && pendingTextRef.current) {
+          void new ClientApiDataSource().saveDraft(ctx, key, channelName, pendingTextRef.current);
+        }
       }
     };
   }, [channelName]);
@@ -62,14 +67,16 @@ export function useDraft(channelName: string | undefined): {
 
   const setDraft = useCallback(
     (text: string) => {
-      setDraftState(text);
+      const isEmpty = !text || emptyText.test(text);
+      setDraftState(isEmpty ? "" : text);
+      pendingTextRef.current = isEmpty ? "" : text;
 
       if (debounceRef.current) clearTimeout(debounceRef.current);
 
       if (!channelRef.current) return;
       const channel = channelRef.current;
 
-      if (!text) {
+      if (isEmpty) {
         // Clear immediately when field is emptied.
         const contextId = getContextId();
         const executorPublicKey = getContextIdentity();
@@ -88,6 +95,7 @@ export function useDraft(channelName: string | undefined): {
 
   const clearDraft = useCallback(() => {
     setDraftState("");
+    pendingTextRef.current = "";
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
@@ -99,5 +107,5 @@ export function useDraft(channelName: string | undefined): {
     void new ClientApiDataSource().deleteDraft(contextId, executorPublicKey, channel);
   }, []);
 
-  return { draft, hasDraft: draft.length > 0, setDraft, clearDraft };
+  return { draft, hasDraft: draft.length > 0 && !emptyText.test(draft), setDraft, clearDraft };
 }

--- a/app/src/hooks/useDraft.ts
+++ b/app/src/hooks/useDraft.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getContextId, getContextIdentity } from "@calimero-network/mero-react";
+import { ClientApiDataSource } from "../api/dataSource/clientApiDataSource";
+
+const DEBOUNCE_MS = 4_000;
+
+/**
+ * Manages a per-channel message draft backed by WASM storage.
+ *
+ * - Loads the persisted draft whenever `channelName` changes.
+ * - Debounces saves: calling `setDraft` queues a WASM write 4s after the
+ *   last keystroke.
+ * - Deletes the WASM draft when `clearDraft` is called (on send or empty).
+ */
+export function useDraft(channelName: string | undefined): {
+  draft: string;
+  hasDraft: boolean;
+  setDraft: (text: string) => void;
+  clearDraft: () => void;
+} {
+  const [draft, setDraftState] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const channelRef = useRef(channelName);
+  channelRef.current = channelName;
+
+  // Load draft when channel changes.
+  useEffect(() => {
+    if (!channelName) {
+      setDraftState("");
+      return;
+    }
+    const contextId = getContextId();
+    const executorPublicKey = getContextIdentity();
+    if (!contextId || !executorPublicKey) {
+      setDraftState("");
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      const res = await new ClientApiDataSource().getDraft(contextId, executorPublicKey, channelName);
+      if (cancelled) return;
+      setDraftState(res.data ?? "");
+    })();
+
+    return () => {
+      cancelled = true;
+      // Flush any pending save for the channel we're leaving.
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, [channelName]);
+
+  const persistDraft = useCallback((channel: string, text: string) => {
+    const contextId = getContextId();
+    const executorPublicKey = getContextIdentity();
+    if (!contextId || !executorPublicKey) return;
+    void new ClientApiDataSource().saveDraft(contextId, executorPublicKey, channel, text);
+  }, []);
+
+  const setDraft = useCallback(
+    (text: string) => {
+      setDraftState(text);
+
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+
+      if (!channelRef.current) return;
+      const channel = channelRef.current;
+
+      if (!text) {
+        // Clear immediately when field is emptied.
+        const contextId = getContextId();
+        const executorPublicKey = getContextIdentity();
+        if (contextId && executorPublicKey) {
+          void new ClientApiDataSource().deleteDraft(contextId, executorPublicKey, channel);
+        }
+        return;
+      }
+
+      debounceRef.current = setTimeout(() => {
+        persistDraft(channel, text);
+      }, DEBOUNCE_MS);
+    },
+    [persistDraft],
+  );
+
+  const clearDraft = useCallback(() => {
+    setDraftState("");
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    const contextId = getContextId();
+    const executorPublicKey = getContextIdentity();
+    const channel = channelRef.current;
+    if (!contextId || !executorPublicKey || !channel) return;
+    void new ClientApiDataSource().deleteDraft(contextId, executorPublicKey, channel);
+  }, []);
+
+  return { draft, hasDraft: draft.length > 0, setDraft, clearDraft };
+}

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -454,6 +454,9 @@ pub struct MeroChat {
     /// Written by delete_message regardless of AuthoredVector ownership, so
     /// admins/mods can delete messages they didn't author.
     deleted_messages: UnorderedSet<String>,
+    /// Per-user per-channel draft text. Key: "{base58_user_id}:{channel_name}".
+    /// Effectively private — each user only reads/writes their own keys.
+    drafts: UnorderedMap<String, LwwRegister<String>>,
 }
 
 #[app::logic]
@@ -500,6 +503,7 @@ impl MeroChat {
             roles,
             read_receipts: UnorderedMap::new(),
             deleted_messages: UnorderedSet::new(),
+            drafts: UnorderedMap::new(),
         }
     }
 
@@ -668,20 +672,39 @@ impl MeroChat {
 
         let executor_id = Self::executor_id();
 
+        // Announce avatar blob to this context so it replicates to other nodes.
+        let avatar_register: Option<LwwRegister<String>> = if let Some(ref blob_id_str) = avatar {
+            match parse_blob_id_base58(blob_id_str) {
+                Ok(blob_id) => {
+                    let context_id = env::context_id();
+                    if !env::blob_announce_to_context(&blob_id, &context_id) {
+                        app::log!(
+                            "Warning: failed to announce avatar blob {} to context",
+                            blob_id_str
+                        );
+                    }
+                    Some(LwwRegister::new(blob_id_str.clone()))
+                }
+                Err(e) => return Err(format!("Invalid avatar blob ID: {e}")),
+            }
+        } else {
+            None
+        };
+
         if self.profiles.contains(&executor_id).unwrap_or(false) {
             // Preserve the frozen username; only the avatar is mutable.
             if let Ok(Some(existing)) = self.profiles.get(&executor_id) {
                 let frozen_username = existing.username.get().clone();
                 let new_profile = StoredProfile {
                     username: LwwRegister::new(frozen_username),
-                    avatar: avatar.map(LwwRegister::new),
+                    avatar: avatar_register,
                 };
                 let _ = self.profiles.update(&executor_id, new_profile);
             }
         } else {
             let profile = StoredProfile {
                 username: LwwRegister::new(username),
-                avatar: avatar.map(LwwRegister::new),
+                avatar: avatar_register,
             };
             let _ = self.profiles.insert(executor_id, profile);
         }
@@ -702,6 +725,53 @@ impl MeroChat {
             }
         }
         result
+    }
+
+    // ── Drafts ─────────────────────────────────────────────────────────────
+
+    /// Save a draft for the calling user in the given channel.
+    /// Passing an empty string is equivalent to deleting the draft.
+    pub fn save_draft(&mut self, channel: String, text: String) -> app::Result<(), String> {
+        self.require_not_banned()?;
+        let key = format!(
+            "{}:{}",
+            encode_blob_id_base58(&env::executor_id()),
+            channel
+        );
+        if text.is_empty() {
+            let _ = self.drafts.remove(&key);
+        } else {
+            let _ = self.drafts.insert(key, LwwRegister::new(text));
+        }
+        Ok(())
+    }
+
+    /// Return the calling user's draft for the given channel, or an empty
+    /// string if none exists.
+    pub fn get_draft(&self, channel: String) -> String {
+        let key = format!(
+            "{}:{}",
+            encode_blob_id_base58(&env::executor_id()),
+            channel
+        );
+        self.drafts
+            .get(&key)
+            .ok()
+            .flatten()
+            .map(|r| r.get().clone())
+            .unwrap_or_default()
+    }
+
+    /// Delete the calling user's draft for the given channel.
+    pub fn delete_draft(&mut self, channel: String) -> app::Result<(), String> {
+        self.require_not_banned()?;
+        let key = format!(
+            "{}:{}",
+            encode_blob_id_base58(&env::executor_id()),
+            channel
+        );
+        let _ = self.drafts.remove(&key);
+        Ok(())
     }
 
     // ── Moderation: roles + ban gate ───────────────────────────────────────

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -40,6 +40,12 @@ fn parse_blob_id_base58(blob_id_str: &str) -> Result<[u8; BLOB_ID_SIZE], String>
     }
 }
 
+/// Build the storage key for a user's per-channel draft.
+/// Format: "<base58_user_id>:<channel_name>"
+fn draft_key(user_base58: &str, channel: &str) -> String {
+    format!("{user_base58}:{channel}")
+}
+
 fn serialize_blob_id_bytes<S>(
     blob_id_bytes: &[u8; BLOB_ID_SIZE],
     serializer: S,
@@ -733,11 +739,7 @@ impl MeroChat {
     /// Passing an empty string is equivalent to deleting the draft.
     pub fn save_draft(&mut self, channel: String, text: String) -> app::Result<(), String> {
         self.require_not_banned()?;
-        let key = format!(
-            "{}:{}",
-            encode_blob_id_base58(&env::executor_id()),
-            channel
-        );
+        let key = draft_key(&encode_blob_id_base58(&env::executor_id()), &channel);
         if text.is_empty() {
             let _ = self.drafts.remove(&key);
         } else {
@@ -749,11 +751,7 @@ impl MeroChat {
     /// Return the calling user's draft for the given channel, or an empty
     /// string if none exists.
     pub fn get_draft(&self, channel: String) -> String {
-        let key = format!(
-            "{}:{}",
-            encode_blob_id_base58(&env::executor_id()),
-            channel
-        );
+        let key = draft_key(&encode_blob_id_base58(&env::executor_id()), &channel);
         self.drafts
             .get(&key)
             .ok()
@@ -765,11 +763,7 @@ impl MeroChat {
     /// Delete the calling user's draft for the given channel.
     pub fn delete_draft(&mut self, channel: String) -> app::Result<(), String> {
         self.require_not_banned()?;
-        let key = format!(
-            "{}:{}",
-            encode_blob_id_base58(&env::executor_id()),
-            channel
-        );
+        let key = draft_key(&encode_blob_id_base58(&env::executor_id()), &channel);
         let _ = self.drafts.remove(&key);
         Ok(())
     }
@@ -1372,7 +1366,7 @@ impl MeroChat {
 
 #[cfg(test)]
 mod tests {
-    use super::{encode_blob_id_base58, parse_blob_id_base58, Role, BLOB_ID_SIZE};
+    use super::{draft_key, encode_blob_id_base58, parse_blob_id_base58, Role, BLOB_ID_SIZE};
 
     // ── Role-based delete permission logic ─────────────────────────────────────
 
@@ -1480,5 +1474,73 @@ mod tests {
     #[test]
     fn blob_id_size_constant_matches_32() {
         assert_eq!(BLOB_ID_SIZE, 32);
+    }
+
+    // ── Draft key format ────────────────────────────────────────────────────
+
+    #[test]
+    fn draft_key_contains_user_and_channel() {
+        let user = "SomeBase58UserId";
+        let key = draft_key(user, "general");
+        assert_eq!(key, "SomeBase58UserId:general");
+    }
+
+    #[test]
+    fn draft_key_separator_is_colon() {
+        let key = draft_key("abc", "my-channel");
+        let parts: Vec<&str> = key.splitn(2, ':').collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0], "abc");
+        assert_eq!(parts[1], "my-channel");
+    }
+
+    #[test]
+    fn draft_key_with_real_base58_user_id() {
+        let user_bytes = [0x01u8; BLOB_ID_SIZE];
+        let user_b58 = encode_blob_id_base58(&user_bytes);
+        let key = draft_key(&user_b58, "announcements");
+        assert!(key.starts_with(&user_b58));
+        assert!(key.ends_with(":announcements"));
+    }
+
+    #[test]
+    fn draft_key_different_users_produce_different_keys() {
+        let user_a = encode_blob_id_base58(&[0x01u8; BLOB_ID_SIZE]);
+        let user_b = encode_blob_id_base58(&[0x02u8; BLOB_ID_SIZE]);
+        let key_a = draft_key(&user_a, "general");
+        let key_b = draft_key(&user_b, "general");
+        assert_ne!(key_a, key_b);
+    }
+
+    #[test]
+    fn draft_key_same_user_different_channels_produce_different_keys() {
+        let user = encode_blob_id_base58(&[0xaau8; BLOB_ID_SIZE]);
+        let key1 = draft_key(&user, "general");
+        let key2 = draft_key(&user, "random");
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn draft_key_channel_name_with_colon_is_preserved() {
+        // Channel names shouldn't contain colons, but the key builder must
+        // not silently corrupt them if they do — splitn(2) guarantees the
+        // channel portion is still recoverable.
+        let key = draft_key("user123", "chan:with:colons");
+        let parts: Vec<&str> = key.splitn(2, ':').collect();
+        assert_eq!(parts[1], "chan:with:colons");
+    }
+
+    #[test]
+    fn draft_key_empty_channel_name() {
+        let key = draft_key("userXYZ", "");
+        assert_eq!(key, "userXYZ:");
+    }
+
+    #[test]
+    fn draft_key_is_deterministic() {
+        let user = encode_blob_id_base58(&[0x55u8; BLOB_ID_SIZE]);
+        let k1 = draft_key(&user, "stable");
+        let k2 = draft_key(&user, "stable");
+        assert_eq!(k1, k2);
     }
 }

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -699,11 +699,12 @@ impl MeroChat {
 
         if self.profiles.contains(&executor_id).unwrap_or(false) {
             // Preserve the frozen username; only the avatar is mutable.
+            // If no new avatar is provided (caller passed null), keep the existing one.
             if let Ok(Some(existing)) = self.profiles.get(&executor_id) {
                 let frozen_username = existing.username.get().clone();
                 let new_profile = StoredProfile {
                     username: LwwRegister::new(frozen_username),
-                    avatar: avatar_register,
+                    avatar: avatar_register.or(existing.avatar),
                 };
                 let _ = self.profiles.update(&executor_id, new_profile);
             }


### PR DESCRIPTION
## Summary

- **Settings cleanup**: Remove stray "Session" label from logout section; when workspace has no stored alias show full ID with a copy button instead of truncated ID+ellipsis
- **Profile avatar**: Clicking the avatar opens an image picker → uploads blob via admin-api → propagates `set_profile` with blob ID to every channel/DM context the user is a member of; WASM `set_profile` now calls `blob_announce_to_context` so the blob replicates to other nodes
- **WASM drafts**: `drafts: UnorderedMap<String, LwwRegister<String>>` added to `MeroChat` with `save_draft` / `get_draft` / `delete_draft` — keyed by `"{base58_user_id}:{channel_name}"`, effectively private per user
- **Draft UI**: `useDraft` hook — 4s debounce save, loads from WASM on channel switch and pre-populates the editor, clears on send or empty, shows a "Draft" badge in the message input actions bar

## Test plan

- [ ] Open Settings → verify no "Session" label; if workspace has no alias full ID is shown with working copy button
- [ ] Click profile avatar → pick an image → verify it uploads and displays immediately; check other channels also show the new avatar (requires 2-node stack for replication test)
- [ ] Type a message but don't send → wait 4s → switch channel → switch back → verify text is pre-populated and "Draft" badge shows
- [ ] Send the drafted message → verify draft clears, badge disappears
- [ ] Clear the input → verify draft clears immediately (no WASM draft on channel switch back)
- [ ] `pnpm exec vitest run` — all 171 unit tests pass
- [ ] `cargo check` — WASM compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new persisted state in the WASM contract (draft storage + profile/avatar handling) and new client-side caching/invalidation that could affect data consistency across contexts or leak object URLs if mismanaged.
> 
> **Overview**
> Adds **WASM-backed per-user, per-channel message drafts** (`save_draft`/`get_draft`/`delete_draft`) plus a new `useDraft` hook that loads drafts on channel switch, debounces saves, pre-populates `MessageInput`, clears on send/empty, and shows a `Draft` badge.
> 
> Introduces **async identity avatars** via `IdentityAvatar` + `useAvatarUrl` (profile lookup + blob download with caching/invalidation), replaces multiple `Avatar` usages across chat/admin UI, and extends Settings to support **click-to-upload profile pictures** (blob upload + best-effort propagation to all group contexts) and improved workspace ID display/copy; WASM `set_profile` now announces avatar blobs for replication and preserves existing avatar when `null` is passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 163c4a936116f3c5b1a23c3106d64a1938536bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->