### PR TITLE
chore: bump calimero SDK deps to 0.10.1-rc.42

### DIFF
--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -1,6 +1,6 @@
 # TODO BEFORE MERGE: revert calimero-sdk/storage/wasm-abi to "edge" (or the
 # published stable tag) instead of the pinned rc below. The rc pin is here so
-# local builds match the dev merod binary (0.10.1-rc.39). On main these should
+# local builds match the dev merod binary (0.10.1-rc.42). On main these should
 # track the latest published release so CI doesn't break on the next rc bump.
 
 [package]
@@ -17,13 +17,13 @@ base64 = "0.22.1"
 borsh = "0.10.3"
 borsh-derive = "0.10.3"
 bs58 = "0.5.1"
-calimero-sdk = "0.10.1-rc.39"
-calimero-storage = "0.10.1-rc.39"
-calimero-storage-macros = "0.10.1-rc.39"
+calimero-sdk = "0.10.1-rc.42"
+calimero-storage = "0.10.1-rc.42"
+calimero-storage-macros = "0.10.1-rc.42"
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = "0.10.1-rc.39"
+calimero-wasm-abi = "0.10.1-rc.42"
 serde_json = "1.0.113"
 
 [profile.app-release]


### PR DESCRIPTION
## Summary
- Updates `calimero-sdk`, `calimero-storage`, `calimero-storage-macros`, and `calimero-wasm-abi` in `logic/Cargo.toml` from `0.10.1-rc.39` to `0.10.1-rc.42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only bump in `logic/Cargo.toml`; main impact is potential build/runtime behavior changes coming from upstream Calimero crates.
> 
> **Overview**
> Updates the pinned Calimero Rust dependencies in `logic/Cargo.toml` from `0.10.1-rc.39` to `0.10.1-rc.42` (`calimero-sdk`, `calimero-storage`, `calimero-storage-macros`, and build-time `calimero-wasm-abi`), and refreshes the accompanying comment to match the new dev `merod` version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e6402e423755e289d407bba3954ec3ca7f7520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->