### PR TITLE
fix: namespace entry UX improvements

### DIFF
--- a/app/dev-dist/sw.js
+++ b/app/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-c6a197bf'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.lctposhb5bk"
+    "revision": "0.vfjepbsqle8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/app/src/components/popups/NamespaceEntryPopup.tsx
+++ b/app/src/components/popups/NamespaceEntryPopup.tsx
@@ -246,6 +246,23 @@ const Divider = styled.div`
   margin: 1rem 0;
 `;
 
+const OrDivider = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0.75rem 0;
+  color: rgba(255, 255, 255, 0.25);
+  font-size: 0.75rem;
+
+  &::before,
+  &::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.08);
+  }
+`;
+
 const LogoutBtn = styled.button`
   background: none;
   border: none;
@@ -466,6 +483,7 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
 
       setStep("enter-name");
     } catch (err) {
+      clearInvitationFromStorage();
       setError(err instanceof Error ? err.message : "Failed to process invitation");
       setStep("error");
     }
@@ -720,6 +738,7 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
             <CreateLink onClick={() => { setError(""); setNsNameInput(""); setStep("create"); }}>
               + Create new workspace
             </CreateLink>
+            <OrDivider>or</OrDivider>
             <CreateLink onClick={() => { setError(""); setJoinInviteInput(""); setStep("join-invitation"); }}>
               Join existing workspace
             </CreateLink>
@@ -759,16 +778,14 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
             >
               Join chat
             </Button>
-            {namespaces.length > 1 && (
-              <Button
-                type="button"
-                variant="secondary"
-                style={{ width: "100%", marginTop: "0.5rem" }}
-                onClick={() => setStep("select")}
-              >
-                ← Back
-              </Button>
-            )}
+            <Button
+              type="button"
+              variant="secondary"
+              style={{ width: "100%", marginTop: "0.5rem" }}
+              onClick={() => setStep("select")}
+            >
+              ← Back
+            </Button>
             <Divider />
             <LogoutBtn onClick={onLogout}>Disconnect node</LogoutBtn>
           </>
@@ -790,6 +807,7 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
             >
               Create workspace
             </Button>
+            <OrDivider>or</OrDivider>
             <CreateLink onClick={() => { setError(""); setJoinInviteInput(""); setStep("join-invitation"); }}>
               Join existing workspace
             </CreateLink>
@@ -906,19 +924,19 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
             <Row>
               <Button
                 type="button"
-                variant="primary"
-                style={{ flex: 1 }}
-                onClick={() => void loadNamespaces()}
-              >
-                Retry
-              </Button>
-              <Button
-                type="button"
                 variant="secondary"
                 style={{ flex: 1 }}
                 onClick={() => { setError(""); setStep(namespaces.length > 0 ? "select" : "no-workspace"); }}
               >
                 ← Back
+              </Button>
+              <Button
+                type="button"
+                variant="primary"
+                style={{ flex: 1 }}
+                onClick={() => void loadNamespaces()}
+              >
+                Retry
               </Button>
             </Row>
           </>

--- a/app/src/components/popups/NamespaceEntryPopup.tsx
+++ b/app/src/components/popups/NamespaceEntryPopup.tsx
@@ -782,7 +782,7 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
               type="button"
               variant="secondary"
               style={{ width: "100%", marginTop: "0.5rem" }}
-              onClick={() => setStep("select")}
+              onClick={() => { setError(""); setStep("select"); }}
             >
               ← Back
             </Button>


### PR DESCRIPTION
## Summary

- **Clear invite on failure** — when joining a namespace via invitation fails, the invite is now cleared from storage so re-opening the app doesn't silently retry the failed join
- **Button order** — error step now shows `← Back | Retry` instead of `Retry | ← Back` (natural left-to-right order)
- **Back button always visible** on the enter-name step — was conditionally hidden when only 1 namespace existed, blocking users from navigating back to create/join options
- **"or" divider** between Create and Join workspace options in both the `no-workspace` and `select` steps

## Test plan

- [ ] Trigger a join failure (bad invite code) → verify error screen shows Back on left, Retry on right
- [ ] Click Back from error → verify app goes to no-workspace/select and doesn't retry on next open
- [ ] With 1 namespace, reach enter-name step → verify Back button is visible and navigates back to select
- [ ] Open no-workspace step → verify "or" divider appears between Create and Join options
- [ ] Open select step → verify "or" divider appears between the two action links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to popup UI flow and local invitation cleanup, with no new backend/API behavior beyond clearing stored data and reordering navigation actions.
> 
> **Overview**
> Improves the `NamespaceEntryPopup` workspace entry UX by adding an `or` divider between create/join actions and ensuring the *Back* button is always available on the name-entry step.
> 
> Fixes invitation-join failure handling by clearing any stored invitation on error to avoid repeated auto-retries, and tweaks the error screen button order/behavior to prefer **Back** navigation vs **Retry** (while keeping retry available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b6ebb9bd90dd6b2dffeb8cd1444b9b552fa6ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->