### PR TITLE
fix: clear stale localStorage and prevent MeroProvider token override on SSO open

### DIFF
--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -24,13 +24,35 @@ purgeLegacyIdentityDisplayNames();
 
 import 'react-photo-view/dist/react-photo-view.css';
 
+// Session-specific keys that become stale across SSO opens and must be
+// cleared so the app starts fresh rather than navigating into old state.
+const SESSION_STALE_KEYS = [
+  "calimero_group_id",
+  "calimero_group_member_identities",
+  "calimero_context_member_identities",
+  "lastSession",
+];
+
+function clearStaleSessionData() {
+  for (const key of SESSION_STALE_KEYS) {
+    localStorage.removeItem(key);
+  }
+  // Clear dynamic sessionLastActivity_* keys
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i);
+    if (k && k.startsWith("sessionLastActivity")) toRemove.push(k);
+  }
+  toRemove.forEach((k) => localStorage.removeItem(k));
+}
+
 // Tauri SSO and web-auth callbacks deliver fresh tokens via URL hash.
 // MeroProvider's internal `LocalStorageTokenStore()` reads tokens as a
 // single JSON blob at `mero-tokens`; persist the hash values there before
 // React mounts (effects would be too late).
 //
-// Returns the parsed hash params if SSO tokens were found, so the async
-// boot can refresh them if they're already expired.
+// Also clears stale session navigation keys so the app starts fresh.
+// Returns the parsed hash params so the async boot can refresh if expired.
 function persistAuthHashOnLoad(): { accessToken: string; refreshToken: string; nodeUrl: string; expiresAt: number } | null {
   const hash = window.location.hash.slice(1);
   if (!hash) return null;
@@ -42,6 +64,9 @@ function persistAuthHashOnLoad(): { accessToken: string; refreshToken: string; n
   if (nodeUrl) setNodeUrl(nodeUrl.trim());
   if (accessToken && refreshToken) {
     const expiresAtMs = expiresAt ? parseInt(expiresAt, 10) : Date.now() + 3600_000;
+    // Clear stale session data before writing new tokens — prevents the app
+    // from loading into a stale group/context from a previous SSO session.
+    clearStaleSessionData();
     localStorage.setItem(
       "mero-tokens",
       JSON.stringify({
@@ -110,7 +135,8 @@ function getExplicitApplicationId(): string {
 }
 
 const explicitApplicationId = getExplicitApplicationId();
-if (explicitApplicationId && !localStorage.getItem(CALIMERO_APP_ID_KEY)) {
+// Always overwrite — hash app-id must win over any stale value from a previous session.
+if (explicitApplicationId) {
   localStorage.setItem(CALIMERO_APP_ID_KEY, explicitApplicationId);
 }
 

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -75,6 +75,13 @@ function persistAuthHashOnLoad(): { accessToken: string; refreshToken: string; n
         expires_at: expiresAtMs,
       }),
     );
+    // Remove the hash so MeroProvider's parseAuthCallback doesn't re-process
+    // the original tokens and overwrite the (possibly refreshed) ones we just wrote.
+    window.history.replaceState(
+      {},
+      "",
+      window.location.pathname + window.location.search,
+    );
     return { accessToken, refreshToken, nodeUrl: nodeUrl?.trim() ?? "", expiresAt: expiresAtMs };
   }
   return null;


### PR DESCRIPTION
## Summary

Follow-up to #147. Three bugs remained that prevented reliable SSO auth when curb is opened from the desktop:

**1. MeroProvider overwrites refreshed tokens with original expired ones**

`MeroProvider` calls `parseAuthCallback(window.location.href)` during React render. It recognises the SSO hash params (`access_token + refresh_token + node_url`) as an OAuth callback and in its `init()` effect calls `getTokenStore().setTokens({access_token: <ORIGINAL_HASH_TOKEN>})` — overwriting any proactively-refreshed token we wrote in `boot()`. Fix: call `history.replaceState` to strip the hash immediately after writing `mero-tokens`, so `parseAuthCallback` sees nothing and `MeroProvider` reads tokens directly from `mero-tokens`.

**2. Stale session data causes wrong navigation after SSO**

`calimero_group_id`, `lastSession`, `sessionLastActivity*`, and member-identity caches were left over from the previous session. The app navigated into old groups/contexts instead of starting fresh. Fix: `clearStaleSessionData()` is called whenever SSO tokens are detected in the hash.

**3. `calimero-application-id` guarded against update**

The old `!localStorage.getItem(CALIMERO_APP_ID_KEY)` guard meant a stale app-id from a prior session was never replaced by the `app-id` in the new SSO hash. Fix: always overwrite from hash.

## Test plan

- [ ] Open curb from desktop with a fresh token → loads directly into app with clean state
- [ ] Open curb from desktop with an expired token → proactive refresh runs, loads successfully
- [ ] Re-open curb from desktop → stale `calimero_group_id` / `lastSession` are cleared, app starts fresh
- [ ] Open curb directly in browser (no hash) → normal login flow unchanged, no stale data cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the SSO/auth bootstrap path and localStorage token handling; mistakes could break login or cause unexpected session resets across launches.
> 
> **Overview**
> Improves SSO startup reliability by clearing stale session/navigation keys from `localStorage` when auth tokens arrive via the URL hash, preventing the app from restoring a prior group/context after an SSO open.
> 
> After persisting hash-delivered tokens into `mero-tokens`, it now strips the URL hash via `history.replaceState` so `MeroProvider` won’t re-parse the callback and overwrite refreshed tokens. It also always overwrites `calimero-application-id` from the current URL (search/hash) to avoid carrying a stale app id across sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e203f26b4937f22572c097fd286252ed40ec799e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->