### PR TITLE
chore: bump merobox 0.6.18 → 0.6.24 in CI

### DIFF
--- a/.github/workflows/integration-ci.yml
+++ b/.github/workflows/integration-ci.yml
@@ -61,7 +61,7 @@ jobs:
       # ── Install merobox ───────────────────────────────────────────────────────
 
       - name: Install merobox
-        run: pip install merobox==0.6.18 && merobox --version
+        run: pip install merobox==0.6.24 && merobox --version
 
       # ── Start nodes + install curb app + create context + seed messages ───────
       # integration-setup.yml sets stop_all_nodes: false so nodes stay running.

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -58,7 +58,7 @@ jobs:
           cp target/wasm32-unknown-unknown/app-release/curb.wasm res/
 
       - name: Install merobox
-        run: pip install merobox==0.6.18 && merobox --version
+        run: pip install merobox==0.6.24 && merobox --version
 
       - name: Run E2E workflow (3-node)
         working-directory: workflows


### PR DESCRIPTION
## Summary
- Update `merobox` pinned version from `0.6.18` to `0.6.24` (latest) in both CI workflows:
  - `.github/workflows/integration-ci.yml`
  - `.github/workflows/workflow-tests.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin-only change in CI; no application, auth, or runtime code is modified.
> 
> **Overview**
> Pins **`merobox`** from **0.6.18** to **0.6.24** in the CI install steps for **integration** full-stack tests and **workflow** merobox runs. No workflow structure or merobox command usage changes—only the package version installed via `pip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 589d459cc455ef5d40cd9ebca747e01d1f9b2f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->