### PR TITLE
chore: bump Calimero SDK to 0.11.0-rc.6

### DIFF
--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -12,19 +12,19 @@ base64 = "0.22.1"
 borsh = "1.6.1"
 borsh-derive = "1.6.1"
 bs58 = "0.5.1"
-calimero-sdk = "0.11.0-rc.4"
-calimero-storage = "0.11.0-rc.4"
-calimero-storage-macros = "0.11.0-rc.4"
+calimero-sdk = "0.11.0-rc.6"
+calimero-storage = "0.11.0-rc.6"
+calimero-storage-macros = "0.11.0-rc.6"
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = "0.11.0-rc.4"
+calimero-wasm-abi = "0.11.0-rc.6"
 serde_json = "1.0.113"
 
 [dev-dependencies]
 # Enables register_crdt_merge + the native mock host so TestHost can drive the
 # AccessControl writer-set state under `cargo test`.
-calimero-storage = { version = "0.11.0-rc.4", features = ["testing"] }
+calimero-storage = { version = "0.11.0-rc.6", features = ["testing"] }
 
 [profile.app-release]
 inherits = "release"


### PR DESCRIPTION
## What

Bump the Calimero SDK dependencies from `0.11.0-rc.4` to `0.11.0-rc.6` (registry versions) in `logic/Cargo.toml`:

- `calimero-sdk`
- `calimero-storage`
- `calimero-storage-macros`
- `calimero-wasm-abi`
- `calimero-storage` (dev-dependency, `testing` feature)

Cargo.toml-only change.

## Note

At the time of writing, the rc.6 release is incomplete on crates.io — only `calimero-wasm-abi@0.11.0-rc.6` is published; `calimero-sdk`, `calimero-storage`, and `calimero-storage-macros` still top out at rc.5. So `cargo update` (Cargo.lock) and the WASM bundle build are intentionally **not** included here — they'll resolve once the rc.6 crates are (re)published to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
