### PR TITLE
fix: don't auto-create a default "general" channel on namespace creation

### DIFF
--- a/app/src/components/popups/NamespaceEntryPopup.tsx
+++ b/app/src/components/popups/NamespaceEntryPopup.tsx
@@ -6,7 +6,6 @@ import { getNodeUrl } from "@calimero-network/mero-react";
 import { getAuthConfig } from "../../api/meroJsClient";
 import axios from "axios";
 import { GroupApiDataSource } from "../../api/dataSource/groupApiDataSource";
-import { ContextApiDataSource } from "../../api/dataSource/nodeApiDataSource";
 import { ClientApiDataSource } from "../../api/dataSource/clientApiDataSource";
 import type { GroupSummary } from "../../api/groupApi";
 import {
@@ -17,7 +16,6 @@ import {
   setGroupMemberIdentity,
   getStoredGroupAlias,
   setStoredGroupAlias,
-  setContextMemberIdentity,
 } from "../../constants/config";
 import {
   getMessengerDisplayName,
@@ -617,30 +615,6 @@ export default function NamespaceEntryPopup({ isAuthenticated, isConfigSet, onLo
       setStoredGroupAlias(groupId, trimmedNs);
 
       await api.current.setDefaultCapabilities(groupId, { defaultCapabilities: DEFAULT_MEMBER_CAPABILITIES }).catch(() => {});
-
-      // Create initial "general" channel so the namespace has something to chat in.
-      // Goes through createGroupContext so `initializationParams` (required by core)
-      // is byte-encoded with the curb `init` shape — a raw POST omitting it is rejected.
-      try {
-        const ctxRes = await new ContextApiDataSource().createGroupContext({
-          applicationId: appId,
-          protocol: "near",
-          groupId,
-          alias: "general",
-          name: "general",
-          initializationParams: {
-            name: "general",
-            context_type: "Channel",
-            description: "",
-            created_at: Math.floor(Date.now() / 1000),
-            creator_username: "",
-          },
-        });
-        const ctxData = ctxRes.data;
-        if (ctxData?.contextId && ctxData?.memberPublicKey) {
-          setContextMemberIdentity(ctxData.contextId, ctxData.memberPublicKey);
-        }
-      } catch { /* non-fatal — user can create channels from the app */ }
 
       const idRes = await api.current.resolveCurrentMemberIdentity(groupId);
       if (idRes.data?.memberIdentity) {


### PR DESCRIPTION
## What

Creating a namespace immediately spawned a default **"general"** channel context. This removes that side-effect so a new namespace starts **empty** and users create their own channels.

## Why

When a user created a namespace, `handleCreate` in `NamespaceEntryPopup.tsx` did three things:
1. `createGroup` (the namespace)
2. `setDefaultCapabilities`
3. **`createGroupContext({ alias: "general", name: "general", context_type: "Channel" })`** ← the unwanted default

Step 3 is what produced the stray `general` context on every namespace creation.

## Change

- Removed the `createGroupContext` "general" block from `handleCreate` in `app/src/components/popups/NamespaceEntryPopup.tsx`.
- Removed the now-unused `ContextApiDataSource` and `setContextMemberIdentity` imports.

Net effect: namespace creation now only creates the namespace (group) + default capabilities.

## Notes

- The other namespace-creation path (`CreateWorkspacePopup.tsx`) already did **not** auto-create a "general" channel, so behavior is now consistent across both flows.
- No test asserted the "general" creation (the only related test, `CreateWorkspacePopup.test.tsx`, already asserts `createGroupContext` is *not* called), so nothing breaks.
- `tsc --noEmit` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)