### PR TITLE
chore: bump mero-react to ^4.1.1 (rc.9 login-loop fix)

### DIFF
--- a/app/e2e/helpers/auth.ts
+++ b/app/e2e/helpers/auth.ts
@@ -19,7 +19,10 @@ export async function injectMeroAuthTokens(
         "mero-tokens",
         JSON.stringify({
           access_token: accessToken,
-          refresh_token: refreshToken ?? "",
+          // Must be non-empty: mero-js's LocalStorageTokenStore.getTokens()
+          // returns null when either token is falsy, and mero-react ≥4.1.1's
+          // checkAuth treats a null store as unauthenticated.
+          refresh_token: refreshToken || "mock-refresh",
           expires_at: Date.now() + 3600_000,
         }),
       );

--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.1",
     "@calimero-network/mero-js": "^7.0.0",
-    "@calimero-network/mero-react": "^4.1.0",
+    "@calimero-network/mero-react": "^4.1.1",
     "@calimero-network/mero-ui": "1.4.0",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       '@calimero-network/mero-react':
-        specifier: ^4.1.0
-        version: 4.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^4.1.1
+        version: 4.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@calimero-network/mero-ui':
         specifier: 1.4.0
         version: 1.4.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.6.3(@tiptap/pm@3.6.3))(@tiptap/pm@3.6.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -732,8 +732,8 @@ packages:
     resolution: {integrity: sha512-t8sQqw7ndbsI1UE/z/6cl8teVCARrJJ7v/WirbYRpIKMsyaSQlU55q/KGyDItKzjp/b1MU2xbs8qcT0HIQWfGQ==}
     engines: {node: '>=18.0.0'}
 
-  '@calimero-network/mero-react@4.1.0':
-    resolution: {integrity: sha512-Hk+25rEvYQrtUsFaiJTVXhPl+zWkbpshcEH6mlqrO8MDJqnOanRDdNvEP2Y7gUEV+LR+D03IcKGaWa06y1Lq9A==}
+  '@calimero-network/mero-react@4.1.1':
+    resolution: {integrity: sha512-K3ukveEop/RllaB8/c2Geq2F2qhCB5AF67ogCV21acht3GEtW1YWQxSFopjkcWKBpJLAYBZc3khVlG6KRWP50Q==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5127,7 +5127,7 @@ snapshots:
 
   '@calimero-network/mero-js@7.0.0': {}
 
-  '@calimero-network/mero-react@4.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@calimero-network/mero-react@4.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@calimero-network/mero-js': 6.1.0
       react: 19.2.7


### PR DESCRIPTION
mero-react **4.1.1** ships the rc.9 login-loop fix (calimero-network/mero-react#41): `checkAuth` now probes permission-free `GET /auth/validate` instead of `GET /admin-api/contexts`, which cores ≥0.11.0-rc.9 (scope enforcement, calimero-network/core#3040) 403 for single-context tokens — bouncing the app back to login forever.

The `^4.1.0` range already allowed 4.1.1, but the lockfile pinned 4.1.0 exactly; this refreshes it. Companion token-minting fix: calimero-network/auth-frontend#33 (ships with the next node release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)