### PR TITLE
chore(logic): pin core SDK to 0.11.0-rc.11

### DIFF
--- a/logic/Cargo.lock
+++ b/logic/Cargo.lock
@@ -25,6 +25,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,7 +99,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 [[package]]
 name = "calimero-prelude"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "borsh",
  "calimero-primitives",
@@ -104,7 +110,7 @@ dependencies = [
 [[package]]
 name = "calimero-primitives"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "borsh",
  "bs58",
@@ -122,7 +128,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -138,7 +144,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -151,7 +157,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -173,7 +179,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "quote",
  "syn",
@@ -182,7 +188,7 @@ dependencies = [
 [[package]]
 name = "calimero-sys"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "cfg-if",
 ]
@@ -190,7 +196,7 @@ dependencies = [
 [[package]]
 name = "calimero-wasm-abi"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.8#476e52e135b271f89a6bf08b8422866258dc03bb"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
 dependencies = [
  "proc-macro2",
  "serde",
@@ -648,12 +654,13 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -1183,6 +1190,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/logic/Cargo.lock
+++ b/logic/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 [[package]]
 name = "calimero-prelude"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "borsh",
  "calimero-primitives",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "calimero-primitives"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "borsh",
  "bs58",
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "quote",
  "syn",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "calimero-sys"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "cfg-if",
 ]
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "calimero-wasm-abi"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.10#42096e9cbe0cfa84b4cbe4b633442f8c064f2906"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.11#9378fbaf6061024a24390eca6a26130ef516b721"
 dependencies = [
  "proc-macro2",
  "serde",

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -12,19 +12,19 @@ base64 = "0.22.1"
 borsh = "1.6.1"
 borsh-derive = "1.6.1"
 bs58 = "0.5.1"
-calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.8" }
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.8" }
-calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.8" }
+calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
+calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.8" }
+calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
 serde_json = "1.0.113"
 
 [dev-dependencies]
 # Enables register_crdt_merge + the native mock host so TestHost can drive the
 # AccessControl writer-set state under `cargo test`.
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.8", features = ["testing"] }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10", features = ["testing"] }
 
 [profile.app-release]
 inherits = "release"

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -12,19 +12,19 @@ base64 = "0.22.1"
 borsh = "1.6.1"
 borsh-derive = "1.6.1"
 bs58 = "0.5.1"
-calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
-calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
+calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.11" }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.11" }
+calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.11" }
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10" }
+calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.11" }
 serde_json = "1.0.113"
 
 [dev-dependencies]
 # Enables register_crdt_merge + the native mock host so TestHost can drive the
 # AccessControl writer-set state under `cargo test`.
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.10", features = ["testing"] }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.11", features = ["testing"] }
 
 [profile.app-release]
 inherits = "release"

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -2,6 +2,7 @@ use calimero_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use calimero_sdk::serde::{Deserialize, Serialize};
 use calimero_sdk::{app, env, BlobId, PublicKey};
 use calimero_storage::collections::crdt_meta::MergeError;
+use calimero_storage::collections::rekey::RekeyTarget;
 use calimero_storage::collections::{
     AccessControl, AuthoredMap, AuthoredVector, LwwRegister, Mergeable as MergeableTrait,
     UnorderedMap, UnorderedSet, Vector,
@@ -48,6 +49,12 @@ impl MergeableTrait for Attachment {
         }
         Ok(())
     }
+}
+
+// `Mergeable` requires `RekeyTarget` (rc.8+). `Attachment` holds only leaf
+// fields (no nested collections), so re-keying is a no-op.
+impl RekeyTarget for Attachment {
+    fn rekey_relative_to(&mut self, _parent_id: calimero_storage::address::Id) {}
 }
 
 impl Attachment {
@@ -176,6 +183,64 @@ impl MergeableTrait for Message {
             }
         }
         Ok(())
+    }
+}
+
+// `Mergeable` requires `RekeyTarget` (rc.8+). Mirrors what `#[derive(Mergeable)]`
+// would emit: deterministically re-key each field's nested collection ids under
+// a field-namespaced child of the entry id, so replicas converge. The
+// autoref-dispatching macro re-keys collection fields (`UnorderedSet`, `Vector`)
+// and no-ops on leaf fields (`LwwRegister`, `Option<..>`, `UserId`).
+impl RekeyTarget for Message {
+    fn rekey_relative_to(&mut self, parent_id: calimero_storage::address::Id) {
+        use calimero_storage::collections::rekey::field_child_id;
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.timestamp,
+            field_child_id(parent_id, "timestamp")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.sender_username,
+            field_child_id(parent_id, "sender_username")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.mentions,
+            field_child_id(parent_id, "mentions")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.mentions_usernames,
+            field_child_id(parent_id, "mentions_usernames")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.files,
+            field_child_id(parent_id, "files")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.images,
+            field_child_id(parent_id, "images")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.id,
+            field_child_id(parent_id, "id")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.text,
+            field_child_id(parent_id, "text")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.edited_on,
+            field_child_id(parent_id, "edited_on")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.deleted,
+            field_child_id(parent_id, "deleted")
+        );
+    }
+
+    fn register_nested_value_types() {
+        // `Attachment` is the only custom struct nested through this type's
+        // collections (`files`/`images: Vector<Attachment>`); register it so it
+        // is re-keyed when stored, not last-writer-wins'd.
+        calimero_storage::register_rekey_if_supported!(Attachment);
     }
 }
 
@@ -368,6 +433,22 @@ impl MergeableTrait for StoredProfile {
             self.avatar = other.avatar.clone();
         }
         Ok(())
+    }
+}
+
+// `Mergeable` requires `RekeyTarget` (rc.8+). `StoredProfile` holds only
+// `LwwRegister` leaves, so every field re-key dispatches to the no-op arm.
+impl RekeyTarget for StoredProfile {
+    fn rekey_relative_to(&mut self, parent_id: calimero_storage::address::Id) {
+        use calimero_storage::collections::rekey::field_child_id;
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.username,
+            field_child_id(parent_id, "username")
+        );
+        calimero_storage::rekey_field_if_supported!(
+            &mut self.avatar,
+            field_child_id(parent_id, "avatar")
+        );
     }
 }
 


### PR DESCRIPTION
Bumps the calimero core git-tag pins in `logic/Cargo.toml` from **rc.8** to **0.11.0-rc.10** (5 dep lines) ahead of the rc.10 node release.

⚠️ CI will stay red until `calimero-network/core` publishes the `0.11.0-rc.10` tag — no `cargo update` was run for the same reason. Note: this repo was on **rc.8**, so it also crosses the rc.9 breaking change (`Mergeable` now requires a `RekeyTarget` supertrait — hand-written `impl Mergeable` blocks may need a matching impl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)