### PR TITLE
chore: bump mero-react to ^4.3.0 (rc.11 governance grants)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.1",
     "@calimero-network/mero-js": "^7.0.0",
-    "@calimero-network/mero-react": "^4.1.1",
+    "@calimero-network/mero-react": "^4.3.0",
     "@calimero-network/mero-ui": "1.4.0",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       '@calimero-network/mero-react':
-        specifier: ^4.1.1
-        version: 4.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^4.3.0
+        version: 4.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@calimero-network/mero-ui':
         specifier: 1.4.0
         version: 1.4.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.6.3(@tiptap/pm@3.6.3))(@tiptap/pm@3.6.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -732,8 +732,8 @@ packages:
     resolution: {integrity: sha512-t8sQqw7ndbsI1UE/z/6cl8teVCARrJJ7v/WirbYRpIKMsyaSQlU55q/KGyDItKzjp/b1MU2xbs8qcT0HIQWfGQ==}
     engines: {node: '>=18.0.0'}
 
-  '@calimero-network/mero-react@4.1.1':
-    resolution: {integrity: sha512-K3ukveEop/RllaB8/c2Geq2F2qhCB5AF67ogCV21acht3GEtW1YWQxSFopjkcWKBpJLAYBZc3khVlG6KRWP50Q==}
+  '@calimero-network/mero-react@4.3.0':
+    resolution: {integrity: sha512-/3iluOFXNyF0q/w1F/0cItuCr2BpQF7Q4Sb/QmwAf7mNc2IeKSuuLDncIoqAfdnI6kAGVTYLBYq8EayA3GjBqg==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5127,7 +5127,7 @@ snapshots:
 
   '@calimero-network/mero-js@7.0.0': {}
 
-  '@calimero-network/mero-react@4.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@calimero-network/mero-react@4.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@calimero-network/mero-js': 6.1.0
       react: 19.2.7


### PR DESCRIPTION
mero-react **4.3.0** (calimero-network/mero-react#42) requests the `namespace` / `group` / `blob` / `context:alias` / `application:list` grants at login — on core ≥0.11.0-rc.11 this restores workspaces, groups/subgroups, blob upload/fetch, aliases and application listing for app tokens (all admin-only since the rc.9 scope enforcement).

Requires a node running **0.11.0-rc.11+**; users must log in once more to mint a token carrying the new grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)