### PR TITLE
chore(logic): pin core SDK to 0.11.0-rc.13

### DIFF
--- a/logic/Cargo.lock
+++ b/logic/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 [[package]]
 name = "calimero-prelude"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "borsh",
  "calimero-primitives",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "calimero-primitives"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "borsh",
  "bs58",
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "quote",
  "syn",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "calimero-sys"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "cfg-if",
 ]
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "calimero-wasm-abi"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.12#9d510087c5d027de54aa8be6bcee9203d8ba5d68"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
 dependencies = [
  "proc-macro2",
  "serde",

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -12,19 +12,19 @@ base64 = "0.22.1"
 borsh = "1.6.1"
 borsh-derive = "1.6.1"
 bs58 = "0.5.1"
-calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.12" }
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.12" }
-calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.12" }
+calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
+calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.12" }
+calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
 serde_json = "1.0.113"
 
 [dev-dependencies]
 # Enables register_crdt_merge + the native mock host so TestHost can drive the
 # AccessControl writer-set state under `cargo test`.
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.12", features = ["testing"] }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13", features = ["testing"] }
 
 [profile.app-release]
 inherits = "release"


### PR DESCRIPTION
Bumps the five core git-tag deps in logic/ from 0.11.0-rc.12 to 0.11.0-rc.13.

rc.13 picks up the rendezvous re-registration fix (core#3211), NetworkManager discovery e2e coverage (core#3210), and the static-asset perf work (core#3184).

Contract compiles on wasm32 and all 26 tests pass against the new pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only RC patch bump with no logic code changes; behavior shifts come from upstream core, mitigated by reported wasm compile and test pass.
> 
> **Overview**
> Bumps all **Calimero core** git dependencies in `logic/` from **`0.11.0-rc.12`** to **`0.11.0-rc.13`**, including `calimero-sdk`, `calimero-storage`, `calimero-storage-macros`, `calimero-wasm-abi`, and the dev `calimero-storage` testing feature pin. **`logic/Cargo.lock`** is updated to match the new commit on `calimero-network/core`.
> 
> No application source changes—only dependency pins and lockfile resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e181d32ea427e12acd0e35b4fcfd582ecf2f690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->