### PR TITLE
ci: auto-publish logic bundle to App Registry on merge to master

### DIFF
--- a/.github/workflows/deploy-bundle.yml
+++ b/.github/workflows/deploy-bundle.yml
@@ -1,0 +1,124 @@
+# Builds and publishes the logic bundle to the Calimero App Registry on every
+# merge to master that touches logic/. The bundle version is resolved inside
+# build-bundle.sh: it fetches the latest published appVersion for
+# com.calimero.curb from the registry and bumps the patch.
+#
+# Required repository secrets:
+#   MERO_SIGN_KEY              — full JSON content of a mero-sign key file
+#                                ({private_key, public_key, signer_id}); must
+#                                be the key that signed the previous version,
+#                                OR any key if the package is linked to an org
+#                                the API-key owner is a member of.
+#   CALIMERO_REGISTRY_API_KEY  — API token from the registry Organizations
+#                                page (CLI Access section).
+
+name: Deploy Bundle
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'logic/**'
+  workflow_dispatch:
+
+# Queue deploys instead of cancelling: each run resolves its version from the
+# registry, so concurrent runs could race to the same version number.
+concurrency:
+  group: deploy-bundle
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  # Keep in sync with the calimero-sdk tag in logic/Cargo.toml
+  MERO_SIGN_REF: 0.11.0-rc.13
+
+jobs:
+  deploy:
+    name: Build, sign & publish bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Check required secrets
+        env:
+          MERO_SIGN_KEY: ${{ secrets.MERO_SIGN_KEY }}
+          CALIMERO_REGISTRY_API_KEY: ${{ secrets.CALIMERO_REGISTRY_API_KEY }}
+        run: |
+          missing=0
+          [ -n "$MERO_SIGN_KEY" ] || { echo "::error::MERO_SIGN_KEY secret is not set"; missing=1; }
+          [ -n "$CALIMERO_REGISTRY_API_KEY" ] || { echo "::error::CALIMERO_REGISTRY_API_KEY secret is not set"; missing=1; }
+          exit $missing
+
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.89.0"
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-deploy-${{ runner.os }}-${{ hashFiles('logic/Cargo.lock') }}
+          restore-keys: cargo-deploy-${{ runner.os }}-
+
+      - name: Install wasm-opt
+        run: sudo apt-get update -q && sudo apt-get install -y -q binaryen
+
+      - name: Cache mero-sign
+        id: cache-mero-sign
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/mero-sign
+          key: mero-sign-${{ runner.os }}-${{ env.MERO_SIGN_REF }}
+
+      - name: Install mero-sign
+        if: steps.cache-mero-sign.outputs.cache-hit != 'true'
+        run: |
+          cargo install mero-sign --locked \
+            --git https://github.com/calimero-network/core \
+            --tag "$MERO_SIGN_REF"
+
+      - name: Write signing key
+        env:
+          MERO_SIGN_KEY: ${{ secrets.MERO_SIGN_KEY }}
+        run: printf '%s' "$MERO_SIGN_KEY" > "$RUNNER_TEMP/mero-sign-key.json"
+
+      - name: Build & sign bundle
+        env:
+          MERO_SIGN_KEY_FILE: ${{ runner.temp }}/mero-sign-key.json
+        run: ./logic/build-bundle.sh
+
+      - name: Install calimero-registry CLI
+        run: npm install -g @calimero-network/registry-cli
+
+      - name: Publish to App Registry
+        env:
+          CALIMERO_API_KEY: ${{ secrets.CALIMERO_REGISTRY_API_KEY }}
+          CALIMERO_REGISTRY_URL: https://apps.calimero.network
+        run: |
+          shopt -s nullglob
+          mpks=(logic/res/curb-*.mpk)
+          if [ ${#mpks[@]} -ne 1 ]; then
+            echo "::error::expected exactly one .mpk in logic/res, found: ${mpks[*]:-none}"
+            exit 1
+          fi
+          echo "Publishing ${mpks[0]}"
+          calimero-registry bundle push "${mpks[0]}" --remote
+
+      - name: Summary
+        run: |
+          mpk=$(basename logic/res/curb-*.mpk .mpk)
+          version="${mpk#curb-}"
+          {
+            echo "### Bundle published :rocket:"
+            echo ""
+            echo "- **Package:** \`com.calimero.curb\`"
+            echo "- **Version:** \`${version}\`"
+            echo "- **Registry:** https://apps.calimero.network"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-bundle.yml
+++ b/.github/workflows/deploy-bundle.yml
@@ -29,8 +29,11 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  # Keep in sync with the calimero-sdk tag in logic/Cargo.toml
-  MERO_SIGN_REF: 0.11.0-rc.13
+  # Commit the 0.11.0-rc.13 tag points to in calimero-network/core — pinned to
+  # the SHA (not the tag) so a moved tag can't change what gets compiled.
+  # Keep in sync with the calimero-sdk tag in logic/Cargo.toml.
+  MERO_SIGN_REV: 64c17161102cc68c226c5c051315802b95583143
+  REGISTRY_CLI_VERSION: 1.15.2
 
 jobs:
   deploy:
@@ -50,16 +53,16 @@ jobs:
           exit $missing
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master 2026-07
         with:
           toolchain: "1.89.0"
           targets: wasm32-unknown-unknown
 
       - name: Cache Cargo registry
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.1
         with:
           path: |
             ~/.cargo/registry
@@ -72,30 +75,36 @@ jobs:
 
       - name: Cache mero-sign
         id: cache-mero-sign
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.0.1
         with:
           path: ~/.cargo/bin/mero-sign
-          key: mero-sign-${{ runner.os }}-${{ env.MERO_SIGN_REF }}
+          key: mero-sign-${{ runner.os }}-${{ env.MERO_SIGN_REV }}
 
       - name: Install mero-sign
         if: steps.cache-mero-sign.outputs.cache-hit != 'true'
         run: |
           cargo install mero-sign --locked \
             --git https://github.com/calimero-network/core \
-            --tag "$MERO_SIGN_REF"
+            --rev "$MERO_SIGN_REV"
 
       - name: Write signing key
         env:
           MERO_SIGN_KEY: ${{ secrets.MERO_SIGN_KEY }}
-        run: printf '%s' "$MERO_SIGN_KEY" > "$RUNNER_TEMP/mero-sign-key.json"
+        run: |
+          umask 077
+          printf '%s' "$MERO_SIGN_KEY" > "$RUNNER_TEMP/mero-sign-key.json"
 
       - name: Build & sign bundle
         env:
           MERO_SIGN_KEY_FILE: ${{ runner.temp }}/mero-sign-key.json
         run: ./logic/build-bundle.sh
 
+      - name: Remove signing key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/mero-sign-key.json"
+
       - name: Install calimero-registry CLI
-        run: npm install -g @calimero-network/registry-cli
+        run: npm install -g --ignore-scripts "@calimero-network/registry-cli@$REGISTRY_CLI_VERSION"
 
       - name: Publish to App Registry
         env:
@@ -113,8 +122,11 @@ jobs:
 
       - name: Summary
         run: |
-          mpk=$(basename logic/res/curb-*.mpk .mpk)
-          version="${mpk#curb-}"
+          shopt -s nullglob
+          mpks=(logic/res/curb-*.mpk)
+          [ ${#mpks[@]} -eq 1 ] || exit 0
+          version="$(basename "${mpks[0]}" .mpk)"
+          version="${version#curb-}"
           {
             echo "### Bundle published :rocket:"
             echo ""

--- a/logic/.gitignore
+++ b/logic/.gitignore
@@ -1,0 +1,3 @@
+key.json
+calimero.json
+*-key.json

--- a/logic/build-bundle.sh
+++ b/logic/build-bundle.sh
@@ -95,10 +95,22 @@ cat > res/bundle-temp/manifest.json <<EOF
 }
 EOF
 
-# Sign the manifest via core workspace tool
-cargo run --manifest-path ../../core/Cargo.toml -p mero-sign --quiet -- \
-    sign res/bundle-temp/manifest.json \
-    --key ../../core/scripts/test-signing-key/test-key.json
+# ── Signing ─────────────────────────────────────────────────────────────────
+# Key: MERO_SIGN_KEY_FILE env (CI writes the MERO_SIGN_KEY secret to a temp
+# file) → fallback to the core workspace test key for local dev.
+# Tool: mero-sign on PATH (CI installs it from the core repo) → fallback to
+# cargo run against a sibling core checkout.
+SIGN_KEY="${MERO_SIGN_KEY_FILE:-../../core/scripts/test-signing-key/test-key.json}"
+if [ ! -f "$SIGN_KEY" ]; then
+    echo "ERROR: signing key not found: $SIGN_KEY (set MERO_SIGN_KEY_FILE)" >&2
+    exit 1
+fi
+if command -v mero-sign >/dev/null; then
+    mero-sign sign res/bundle-temp/manifest.json --key "$SIGN_KEY"
+else
+    cargo run --manifest-path ../../core/Cargo.toml -p mero-sign --quiet -- \
+        sign res/bundle-temp/manifest.json --key "$SIGN_KEY"
+fi
 
 # Create .mpk bundle (tar.gz archive). Filename derives from APP_VERSION so it
 # never drifts from the manifest appVersion.

--- a/logic/key.json
+++ b/logic/key.json
@@ -1,5 +1,0 @@
-{
-  "private_key": "2eB4bcuAbPu-pw9qP37R9VRKeMxRz0DqrlSD6pK9Ako",
-  "public_key": "0OTcPZ2D1qiZiLooMxjUc9sNkUK728O2eYjFimd-lIo",
-  "signer_id": "did:key:z6MktWhFZS2YcAwB4CaukMc8iC8Fk8VkV8CrGY8FLeK49b6q"
-}


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy-bundle.yml`: on every push to `master` that touches `logic/**` (plus manual `workflow_dispatch`), CI now:

1. Builds the WASM (`rust 1.89.0` + `wasm-opt`, same toolchain as `workflow-tests.yml`)
2. Runs `logic/build-bundle.sh`, which **auto-versions** the bundle — it fetches the latest published `appVersion` for `com.calimero.curb` from the App Registry and bumps the patch (currently `7.0.4` → next publish will be `7.0.5`)
3. Signs the manifest with `mero-sign` (installed from `calimero-network/core@0.11.0-rc.13`, cached), using the key from the `MERO_SIGN_KEY` secret
4. Installs `@calimero-network/registry-cli` and pushes the `.mpk` to `https://apps.calimero.network`, authenticated via the `CALIMERO_REGISTRY_API_KEY` secret

Deploys are queued (not cancelled) under a shared concurrency group so two merges can't race for the same version number.

### build-bundle.sh changes

- Signing key now comes from `MERO_SIGN_KEY_FILE` env when set (CI writes the secret to a temp file); local dev falls back to the core workspace test key as before
- Uses a `mero-sign` binary from `PATH` when available, so CI doesn't need a sibling `core` checkout; falls back to `cargo run` against `../../core` locally

### 🔒 Security

- **Removes `logic/key.json`** — a private Ed25519 signing key that has been committed to this public repo since #119. It never signed any published bundle (the registry's `com.calimero.curb` signer is a different key), so nothing depends on it — but it should be considered burned and never used. It remains in git history.
- Adds `logic/.gitignore` covering `key.json`, `calimero.json`, `*-key.json`

## Required repo secrets (before merging)

| Secret | Value |
|---|---|
| `MERO_SIGN_KEY` | Full JSON content of a mero-sign key file (`{private_key, public_key, signer_id}`). Must be the key that signed the currently published version, **or** any key if the package is org-linked and the API-key owner is an org member. |
| `CALIMERO_REGISTRY_API_KEY` | API token from the registry **Organizations → CLI Access** page. |

## Verified

- Ran the exact CI path locally (`MERO_SIGN_KEY_FILE=… ./build-bundle.sh` with `mero-sign` on PATH): resolved `7.0.5` from the live registry, built, signed, and packed `curb-7.0.5.mpk`; manifest signature block verified and signer matches the published `7.0.4` signer
- `bundle push` flags/env (`CALIMERO_API_KEY`, `CALIMERO_REGISTRY_URL`, `--remote`) confirmed against registry-cli
- `mero-sign` confirmed present at the `0.11.0-rc.13` tag (it is not on crates.io)
- No actual push was made from local — the first real publish happens on the first CI run after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)