### PR TITLE
fix(auth): make token handling safe for single-use refresh tokens

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.1",
-    "@calimero-network/mero-js": "^7.0.0",
+    "@calimero-network/mero-js": "^6.1.0",
     "@calimero-network/mero-react": "^4.3.3",
     "@calimero-network/mero-ui": "1.4.0",
     "@radix-ui/react-accordion": "^1.2.15",

--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.1",
     "@calimero-network/mero-js": "^6.1.0",
-    "@calimero-network/mero-react": "^4.3.3",
+    "@calimero-network/mero-react": "^4.3.4",
     "@calimero-network/mero-ui": "1.4.0",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-dialog": "^1.1.18",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0
       '@calimero-network/mero-react':
-        specifier: ^4.3.3
-        version: 4.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^4.3.4
+        version: 4.3.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@calimero-network/mero-ui':
         specifier: 1.4.0
         version: 1.4.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.6.3(@tiptap/pm@3.6.3))(@tiptap/pm@3.6.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -728,8 +728,8 @@ packages:
     resolution: {integrity: sha512-gYabeP3UfDjmlkHgcVPv9aggFedQDjIhbTbqm54k0CTiEH/1xZEo9yW87av/rxrG7CJg8OXE3VggMluhT6biJg==}
     engines: {node: '>=18.0.0'}
 
-  '@calimero-network/mero-react@4.3.3':
-    resolution: {integrity: sha512-zQzV9xjusAkzJb99I2kSTJmNzjv5y3rM5KemAabkEEgiRcQalcjVLRozh0RdhYTHsZy/mKsel7bejw7JDDcvFw==}
+  '@calimero-network/mero-react@4.3.4':
+    resolution: {integrity: sha512-6Cenm8KBo6LvANunWVvEmhppHB2Tb1dKZtHTcdo7biZ1xVdnAUkzl6Q6QaRmInQ8/ObtiwMC85vLqnQdzv471A==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5133,7 +5133,7 @@ snapshots:
 
   '@calimero-network/mero-js@6.1.0': {}
 
-  '@calimero-network/mero-react@4.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@calimero-network/mero-react@4.3.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@calimero-network/mero-js': 6.1.0
       react: 19.2.7

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1
       '@calimero-network/mero-js':
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@calimero-network/mero-react':
         specifier: ^4.3.3
         version: 4.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -114,6 +114,10 @@ importers:
       zustand:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    optionalDependencies:
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.5
@@ -172,10 +176,6 @@ importers:
       workbox-window:
         specifier: ^7.4.1
         version: 7.4.1
-    optionalDependencies:
-      '@types/react':
-        specifier: 19.2.17
-        version: 19.2.17
 
 packages:
 
@@ -726,10 +726,6 @@ packages:
 
   '@calimero-network/mero-js@6.1.0':
     resolution: {integrity: sha512-gYabeP3UfDjmlkHgcVPv9aggFedQDjIhbTbqm54k0CTiEH/1xZEo9yW87av/rxrG7CJg8OXE3VggMluhT6biJg==}
-    engines: {node: '>=18.0.0'}
-
-  '@calimero-network/mero-js@7.0.0':
-    resolution: {integrity: sha512-t8sQqw7ndbsI1UE/z/6cl8teVCARrJJ7v/WirbYRpIKMsyaSQlU55q/KGyDItKzjp/b1MU2xbs8qcT0HIQWfGQ==}
     engines: {node: '>=18.0.0'}
 
   '@calimero-network/mero-react@4.3.3':
@@ -5136,8 +5132,6 @@ snapshots:
       react: 19.2.7
 
   '@calimero-network/mero-js@6.1.0': {}
-
-  '@calimero-network/mero-js@7.0.0': {}
 
   '@calimero-network/mero-react@4.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:

--- a/app/src/api/MeroJsBridge.tsx
+++ b/app/src/api/MeroJsBridge.tsx
@@ -1,0 +1,26 @@
+import { type ReactNode } from "react";
+import { useMero } from "@calimero-network/mero-react";
+import { setMeroJs } from "./meroJsClient";
+
+/**
+ * Hands MeroProvider's MeroJs instance to the non-React callers in `api/`
+ * (dataSource modules, blob helpers) via a module-level holder.
+ *
+ * Curb used to `new MeroJs(...)` a SECOND instance of its own alongside the one
+ * MeroProvider creates internally. Both pointed at the same `mero-tokens` blob,
+ * but mero-js's refresh single-flight (`refreshTokenPromise`) is per-INSTANCE —
+ * so two instances meant two independent mutexes over one token bundle. With
+ * single-use refresh tokens (core#3083) a concurrent refresh is fatal: whichever
+ * instance loses the race re-presents an already-consumed refresh token, the
+ * server reads that as theft (401 `x-auth-error: token_reuse`) and revokes the
+ * whole token family — logging out every holder. One instance, one mutex.
+ *
+ * Registered during render (not in an effect) so children can reach it in their
+ * own mount effects. The assignment is idempotent, so StrictMode's double render
+ * is harmless.
+ */
+export default function MeroJsBridge({ children }: { children: ReactNode }) {
+  const { mero } = useMero();
+  setMeroJs(mero);
+  return <>{children}</>;
+}

--- a/app/src/api/meroJsClient.ts
+++ b/app/src/api/meroJsClient.ts
@@ -1,25 +1,17 @@
-// Lazy MeroJs singleton + a thin RPC wrapper that preserves the old
-// calimero-client `{ result: { output }, error: { code, error: { cause: { info } } } }`
+// Accessor for MeroProvider's MeroJs instance + a thin RPC wrapper that
+// preserves the old calimero-client
+// `{ result: { output }, error: { code, error: { cause: { info } } } }`
 // envelope shape, so dataSource code can keep its existing access patterns
 // without per-callsite refactors.
 
 import {
-  MeroJs,
-  LocalStorageTokenStore,
+  type MeroJs,
   RpcError,
   type Context,
   type ExecuteParams,
 } from "@calimero-network/mero-js";
 import { getNodeUrl } from "@calimero-network/mero-react";
 import type { ResponseData } from "./types";
-
-// MeroProvider (mero-react) instantiates its internal MeroJs with the
-// default `LocalStorageTokenStore()` — which reads/writes a single JSON
-// blob at `mero-tokens`. We mirror that here so our standalone MeroJs
-// instance shares the same auth state.
-function getMeroTokenStore() {
-  return new LocalStorageTokenStore();
-}
 
 // Helper used by raw-fetch wrappers below + by useSseSubscription.
 export function getJwt(): string {
@@ -33,20 +25,26 @@ export function getJwt(): string {
   }
 }
 
+// The ONE MeroJs instance, owned by MeroProvider and handed to us by
+// <MeroJsBridge> (see api/MeroJsBridge.tsx). We deliberately do not construct
+// our own: mero-js's refresh single-flight is per-instance, so a second instance
+// over the same `mero-tokens` bundle can double-spend a single-use refresh token
+// (core#3083) and get the whole token family revoked.
 let _instance: MeroJs | null = null;
-let _baseUrl: string | null = null;
+
+export function setMeroJs(instance: MeroJs | null): void {
+  _instance = instance;
+}
 
 export function getMeroJs(): MeroJs {
-  const baseUrl = getNodeUrl();
-  if (!baseUrl) {
+  if (!_instance) {
+    // MeroProvider hands us the instance as soon as it has a node URL; a null
+    // instance means we are not connected/authenticated yet.
     throw new Error(
-      "Application endpoint key is missing. Please check your configuration.",
+      getNodeUrl()
+        ? "Mero client is not ready yet. Please retry in a moment."
+        : "Application endpoint key is missing. Please check your configuration.",
     );
-  }
-  if (!_instance || _baseUrl !== baseUrl) {
-    _instance?.close();
-    _instance = new MeroJs({ baseUrl, tokenStore: getMeroTokenStore() });
-    _baseUrl = baseUrl;
   }
   return _instance;
 }

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -7,8 +7,16 @@ import { decodeInvitationPayload } from "./utils/invitation.ts";
 import {
   MeroProvider,
   AppMode as MeroAppMode,
+  getNodeUrl,
   setNodeUrl,
 } from "@calimero-network/mero-react";
+import MeroJsBridge from "./api/MeroJsBridge.tsx";
+import {
+  TOKENS_KEY,
+  jwtExpiryMs,
+  readStoredTokens,
+  shouldSeedTokens,
+} from "./utils/authTokens.ts";
 import "@calimero-network/mero-ui/styles.css";
 import { ToastProvider } from "@calimero-network/mero-ui";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
@@ -46,45 +54,65 @@ function clearStaleSessionData() {
   toRemove.forEach((k) => localStorage.removeItem(k));
 }
 
-// Tauri SSO and web-auth callbacks deliver fresh tokens via URL hash.
-// MeroProvider's internal `LocalStorageTokenStore()` reads tokens as a
-// single JSON blob at `mero-tokens`; persist the hash values there before
-// React mounts (effects would be too late).
+// Tauri SSO and web-auth callbacks deliver tokens via URL hash. MeroProvider's
+// internal `LocalStorageTokenStore()` reads tokens as a single JSON blob at
+// `mero-tokens`; seed the hash values there before React mounts (effects would
+// be too late).
 //
-// Also clears stale session navigation keys so the app starts fresh.
-// Returns the parsed hash params so the async boot can refresh if expired.
-function persistAuthHashOnLoad(): { accessToken: string; refreshToken: string; nodeUrl: string; expiresAt: number } | null {
+// The stored bundle deliberately WINS over the hash unless the hash is genuinely
+// newer — see `shouldSeedTokens` (utils/authTokens.ts) for why clobbering it
+// gets the whole token family revoked under single-use refresh (core#3083).
+function persistAuthHashOnLoad(): void {
   const hash = window.location.hash.slice(1);
-  if (!hash) return null;
+  if (!hash) return;
   const p = new URLSearchParams(hash);
   const accessToken = p.get("access_token");
   const refreshToken = p.get("refresh_token");
   const expiresAt = p.get("expires_at");
-  const nodeUrl = p.get("node_url");
-  if (nodeUrl) setNodeUrl(nodeUrl.trim());
-  if (accessToken && refreshToken) {
-    const expiresAtMs = expiresAt ? parseInt(expiresAt, 10) : Date.now() + 3600_000;
+  const nodeUrl = p.get("node_url")?.trim();
+
+  // Read the node we were last pointed at BEFORE setNodeUrl overwrites it —
+  // a different node means the stored bundle belongs to a foreign token family.
+  const previousNodeUrl = getNodeUrl();
+  if (nodeUrl) setNodeUrl(nodeUrl);
+  if (!accessToken || !refreshToken) return;
+
+  const hashExpiresAtMs =
+    jwtExpiryMs(accessToken) ??
+    (expiresAt ? parseInt(expiresAt, 10) : Date.now() + 3600_000);
+
+  const nodeChanged =
+    !!nodeUrl && !!previousNodeUrl && previousNodeUrl.trim() !== nodeUrl;
+
+  const seed = shouldSeedTokens({
+    hashExpiresAtMs,
+    stored: readStoredTokens(),
+    nodeChanged,
+  });
+
+  if (seed) {
     // Clear stale session data before writing new tokens — prevents the app
     // from loading into a stale group/context from a previous SSO session.
+    // Only on a genuinely new session: re-opening the current one must not
+    // nuke the navigation state out from under a live tab.
     clearStaleSessionData();
     localStorage.setItem(
-      "mero-tokens",
+      TOKENS_KEY,
       JSON.stringify({
         access_token: accessToken,
         refresh_token: refreshToken,
-        expires_at: expiresAtMs,
+        expires_at: hashExpiresAtMs,
       }),
     );
-    // Remove the hash so MeroProvider's parseAuthCallback doesn't re-process
-    // the original tokens and overwrite the (possibly refreshed) ones we just wrote.
-    window.history.replaceState(
-      {},
-      "",
-      window.location.pathname + window.location.search,
-    );
-    return { accessToken, refreshToken, nodeUrl: nodeUrl?.trim() ?? "", expiresAt: expiresAtMs };
   }
-  return null;
+
+  // Remove the hash either way, so MeroProvider's parseAuthCallback doesn't
+  // re-process the original tokens and overwrite the (possibly rotated) bundle.
+  window.history.replaceState(
+    {},
+    "",
+    window.location.pathname + window.location.search,
+  );
 }
 
 // Extract ?invitation= from URL before React mounts — React Router's <Navigate>
@@ -150,40 +178,17 @@ if ("serviceWorker" in navigator && !import.meta.env.DEV) {
 
 const AppWrapper = import.meta.env.DEV ? StrictMode : React.Fragment;
 
-async function boot() {
-  // Persist SSO tokens from the URL hash before React reads localStorage.
-  const sso = persistAuthHashOnLoad();
-
-  // If the desktop passed a token that's already expired (or expires within
-  // 30 s), refresh it now so MeroProvider starts with valid credentials.
-  if (sso && sso.nodeUrl && Date.now() > sso.expiresAt - 30_000) {
-    try {
-      const resp = await fetch(`${sso.nodeUrl}/auth/refresh`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          access_token: sso.accessToken,
-          refresh_token: sso.refreshToken,
-        }),
-      });
-      if (resp.ok) {
-        const json = await resp.json();
-        const refreshed = json?.data ?? json;
-        if (refreshed?.access_token && refreshed?.refresh_token) {
-          localStorage.setItem(
-            "mero-tokens",
-            JSON.stringify({
-              access_token: refreshed.access_token,
-              refresh_token: refreshed.refresh_token,
-              expires_at: Date.now() + 3600_000,
-            }),
-          );
-        }
-      }
-    } catch {
-      // Refresh failed — let MeroProvider handle it reactively.
-    }
-  }
+function boot() {
+  // Seed SSO tokens from the URL hash before React reads localStorage.
+  //
+  // There is deliberately NO proactive refresh here. mero-js refreshes
+  // reactively on a 401 + `x-auth-error: token_expired`, behind a single-flight
+  // mutex. A hand-rolled refresh alongside it would (a) be rejected outright
+  // when the access token is still valid ("Access token still valid" — see
+  // core#3083) and (b) race the SDK's own refresh over the same stored bundle,
+  // so one of the two would present an already-consumed, single-use refresh
+  // token → `token_reuse` → the entire token family is revoked.
+  persistAuthHashOnLoad();
 
   createRoot(document.getElementById("root")!).render(
     <AppWrapper>
@@ -197,17 +202,19 @@ async function boot() {
           packageName={import.meta.env.VITE_APPLICATION_PACKAGE}
           registryUrl="https://apps.calimero.network"
         >
-          <BrowserRouter>
-            <WebSocketProvider>
-              <ToastProvider>
-                <App />
-              </ToastProvider>
-            </WebSocketProvider>
-          </BrowserRouter>
+          <MeroJsBridge>
+            <BrowserRouter>
+              <WebSocketProvider>
+                <ToastProvider>
+                  <App />
+                </ToastProvider>
+              </WebSocketProvider>
+            </BrowserRouter>
+          </MeroJsBridge>
         </MeroProvider>
       </ErrorBoundary>
     </AppWrapper>,
   );
 }
 
-void boot();
+boot();

--- a/app/src/utils/authTokens.test.ts
+++ b/app/src/utils/authTokens.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  TOKENS_KEY,
+  jwtExpiryMs,
+  readStoredTokens,
+  shouldSeedTokens,
+  tokenExpiryMs,
+} from "./authTokens";
+
+/** Build a JWT-shaped token whose `exp` claim sits at `expMs`. */
+function jwt(expMs: number): string {
+  const payload = btoa(JSON.stringify({ exp: Math.floor(expMs / 1000) }))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+  return `header.${payload}.signature`;
+}
+
+const store = (tokens: {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+}) => localStorage.setItem(TOKENS_KEY, JSON.stringify(tokens));
+
+beforeEach(() => localStorage.clear());
+
+describe("jwtExpiryMs", () => {
+  it("reads the `exp` claim as milliseconds", () => {
+    const exp = Date.now() + 60_000;
+    // second-resolution `exp` — compare on the same scale
+    expect(jwtExpiryMs(jwt(exp))).toBe(Math.floor(exp / 1000) * 1000);
+  });
+
+  it("returns null for a non-JWT token", () => {
+    expect(jwtExpiryMs("opaque-token")).toBeNull();
+    expect(jwtExpiryMs("")).toBeNull();
+  });
+});
+
+describe("readStoredTokens", () => {
+  it("returns null when the bundle is absent, corrupt, or half-populated", () => {
+    expect(readStoredTokens()).toBeNull();
+    localStorage.setItem(TOKENS_KEY, "{not json");
+    expect(readStoredTokens()).toBeNull();
+    // mero-js's own store treats a missing refresh_token as unauthenticated
+    store({ access_token: "at", refresh_token: "", expires_at: 1 });
+    expect(readStoredTokens()).toBeNull();
+  });
+
+  it("reads a well-formed bundle", () => {
+    store({ access_token: "at", refresh_token: "rt", expires_at: 42 });
+    expect(readStoredTokens()).toEqual({
+      access_token: "at",
+      refresh_token: "rt",
+      expires_at: 42,
+    });
+  });
+});
+
+describe("tokenExpiryMs", () => {
+  it("prefers the JWT `exp` over the recorded expires_at", () => {
+    const exp = Date.now() + 900_000;
+    expect(
+      tokenExpiryMs({ access_token: jwt(exp), refresh_token: "rt", expires_at: 1 }),
+    ).toBe(Math.floor(exp / 1000) * 1000);
+  });
+
+  it("falls back to expires_at for opaque tokens", () => {
+    expect(
+      tokenExpiryMs({ access_token: "opaque", refresh_token: "rt", expires_at: 77 }),
+    ).toBe(77);
+  });
+});
+
+describe("shouldSeedTokens (single-use refresh — core#3083)", () => {
+  const now = Date.now();
+
+  it("seeds when nothing is stored", () => {
+    expect(
+      shouldSeedTokens({
+        hashExpiresAtMs: now + 60_000,
+        stored: null,
+        nodeChanged: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT clobber a bundle mero-js already rotated past the hash", () => {
+    // The desktop re-opens curb with the bundle it minted at ITS login, while
+    // mero-js has since rotated ours. The stored refresh token is the only live
+    // one; the hash's was consumed by that rotation. Re-presenting it would be
+    // read as theft (401 `token_reuse`) and revoke the whole family.
+    expect(
+      shouldSeedTokens({
+        hashExpiresAtMs: now + 60_000, // desktop's original bundle
+        stored: {
+          access_token: jwt(now + 3_600_000), // rotated: expires later
+          refresh_token: "rotated-rt",
+          expires_at: now + 3_600_000,
+        },
+        nodeChanged: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not re-seed the very same bundle it is already holding", () => {
+    const at = jwt(now + 600_000);
+    expect(
+      shouldSeedTokens({
+        hashExpiresAtMs: Math.floor((now + 600_000) / 1000) * 1000,
+        stored: { access_token: at, refresh_token: "rt", expires_at: 0 },
+        nodeChanged: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("seeds when the hash carries a genuinely newer bundle (a fresh login)", () => {
+    expect(
+      shouldSeedTokens({
+        hashExpiresAtMs: now + 3_600_000,
+        stored: {
+          access_token: jwt(now + 60_000),
+          refresh_token: "old-rt",
+          expires_at: now + 60_000,
+        },
+        nodeChanged: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("seeds when the node changed — the stored bundle is a foreign token family", () => {
+    expect(
+      shouldSeedTokens({
+        hashExpiresAtMs: now + 60_000,
+        stored: {
+          access_token: jwt(now + 3_600_000),
+          refresh_token: "other-node-rt",
+          expires_at: now + 3_600_000,
+        },
+        nodeChanged: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/app/src/utils/authTokens.ts
+++ b/app/src/utils/authTokens.ts
@@ -1,0 +1,80 @@
+// Token-bundle helpers shared by the SSO-hash seeding in main.tsx.
+//
+// mero-js stores auth as a single JSON blob at `mero-tokens` (its
+// LocalStorageTokenStore); MeroProvider reads and rotates that same blob.
+
+export const TOKENS_KEY = "mero-tokens";
+
+export type StoredTokens = {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+};
+
+/**
+ * Expiry straight from the access token's `exp` claim (seconds → ms).
+ *
+ * This is the same source mero-react uses (`parseJwtExpiry`), so a stored bundle
+ * and a hash bundle are always compared on the same scale. Returns null for a
+ * token that isn't a decodable JWT.
+ */
+export function jwtExpiryMs(token: string): number | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const claims = JSON.parse(
+      atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
+    ) as { exp?: number };
+    return typeof claims.exp === "number" ? claims.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readStoredTokens(): StoredTokens | null {
+  try {
+    const raw = localStorage.getItem(TOKENS_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as Partial<StoredTokens>;
+    if (!p?.access_token || !p?.refresh_token) return null;
+    return {
+      access_token: p.access_token,
+      refresh_token: p.refresh_token,
+      expires_at: typeof p.expires_at === "number" ? p.expires_at : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Prefer the JWT's own `exp`; fall back to the recorded `expires_at`. */
+export function tokenExpiryMs(tokens: StoredTokens): number {
+  return jwtExpiryMs(tokens.access_token) ?? tokens.expires_at;
+}
+
+/**
+ * Should the bundle carried in the SSO hash replace what's already stored?
+ *
+ * Refresh tokens are SINGLE-USE (core#3083): every `/auth/refresh` consumes the
+ * presented refresh token and mints a new one. The desktop re-opens this app
+ * with the bundle it minted at *its* login, so the hash routinely carries a
+ * bundle OLDER than the stored one — mero-js may have rotated several times
+ * since. Overwriting the store with the hash would re-present an already
+ * consumed refresh token on the next 401, which the server treats as theft:
+ * 401 `x-auth-error: token_reuse` → the whole token family is revoked → every
+ * holder is hard-logged-out.
+ *
+ * So the stored bundle wins unless it can't be trusted: nothing stored, a
+ * different node (foreign token family), or a genuinely newer hash bundle
+ * (a fresh login).
+ */
+export function shouldSeedTokens(args: {
+  hashExpiresAtMs: number;
+  stored: StoredTokens | null;
+  nodeChanged: boolean;
+}): boolean {
+  const { hashExpiresAtMs, stored, nodeChanged } = args;
+  if (!stored) return true;
+  if (nodeChanged) return true;
+  return hashExpiresAtMs > tokenExpiryMs(stored);
+}


### PR DESCRIPTION
## Why

[calimero-network/core#3083](https://github.com/calimero-network/core/pull/3083) makes refresh tokens **single-use**: every `POST /auth/refresh` consumes the presented refresh token and returns a new one. Re-presenting a consumed refresh token is treated as **theft** — the server answers `401` with `x-auth-error: token_reuse` and **revokes the whole token family**, hard-logging-out every holder. The same endpoint also *rejects a still-valid access token* ("Access token still valid"), so refreshing "early" doesn't just waste a round-trip — it fails.

Curb double-spent its refresh token three separate ways. Each one is enough on its own to get a user's token family revoked.

### 1. A hand-rolled proactive refresh (`main.tsx`)

`boot()` fired a raw `fetch(nodeUrl + '/auth/refresh')` 30s *before* expiry. Two problems: the access token is still valid at that point, so core#3083 **rejects the call outright**; and it bypasses mero-js's single-flight mutex, so it can race the SDK's own refresh — whichever loses presents an already-consumed token.

mero-js already refreshes **reactively**, on `401` + `x-auth-error: token_expired`, behind a single-flight promise (verified in `http-client/web-client.js`). It has no proactive/expiry-based refresh at all. So this code was pure downside: deleted, and refreshing is left to the SDK.

### 2. Two `MeroJs` instances, two mutexes, one token bundle (`api/meroJsClient.ts`)

`getMeroJs()` did `new MeroJs(...)` — a *second* instance alongside the one `MeroProvider` creates internally. Both read/write the same `mero-tokens` blob, but mero-js's refresh single-flight (`this.refreshTokenPromise`) is **per-instance**. Two instances = two independent mutexes over one bundle = concurrent refresh = reuse.

Consolidated onto `MeroProvider`'s instance, exposed via `useMero()` and handed to the non-React `api/` callers by a new `<MeroJsBridge>`.

This also **de-duplicates the mero-js dependency**: the app pulled `^7.0.0` directly while `mero-react@4.3.3` pins `^6.1.0`, so **both** were installed. Beyond the double-instance bug, that meant `e instanceof RpcError` in `rpcExec` compared against a class from a *different physical copy* than the one the throwing client was built from — a silent cross-copy `instanceof` failure. Pinned the app to `^6.1.0` so there is exactly one copy. (There is no mero-react release on mero-js 7 yet; 4.3.3 is latest and still wants `^6.1.0`.) The build confirms the app used no 7.0-only API.

### 3. Clobbering the rotated bundle with the desktop's stale one (`main.tsx`)

`persistAuthHashOnLoad()` unconditionally overwrote `mero-tokens` from the SSO hash on **every** load. The desktop re-opens curb with the bundle it minted at *its* login, so the hash routinely carries a bundle **older** than what's stored — mero-js may have rotated several times since. Overwriting re-presents a refresh token that rotation already consumed → `token_reuse` → family revoked.

Now the stored bundle **wins** unless it can't be trusted: nothing stored, the node changed (foreign token family), or the hash is genuinely newer (a fresh login). Expiry is compared via the access token's own `exp` claim — the same source mero-react uses (`parseJwtExpiry`) — so both bundles are measured on one scale.

## Before → After

| | Before | After |
|---|---|---|
| Proactive refresh | Hand-rolled `fetch`, 30s before expiry → **rejected** ("Access token still valid") and races the SDK | None. mero-js refreshes reactively on `401`/`token_expired` behind its single-flight |
| `MeroJs` instances | **2** (app's own + MeroProvider's) → 2 refresh mutexes over 1 token bundle | **1** (MeroProvider's), shared via `<MeroJsBridge>` |
| mero-js copies installed | **2** (`6.1.0` via mero-react + `7.0.0` direct) → cross-copy `instanceof RpcError` breaks | **1** (`6.1.0`), matching mero-react's pin |
| SSO hash → store | Overwrites `mero-tokens` on every load, clobbering rotated tokens | Seeds only if nothing stored / node changed / hash genuinely newer |
| Consumed refresh token replayed | Likely → `token_reuse` → **whole family revoked, everyone logged out** | Not replayed |

## How to test

```bash
cd app && pnpm install
pnpm run build   # tsc -b && vite build
pnpm run lint    # 0 errors
pnpm run test    # 248 passed (237 pre-existing + 11 new)
```

New unit tests in `src/utils/authTokens.test.ts` pin the seeding rule that keeps the family alive — most importantly **"does NOT clobber a bundle mero-js already rotated past the hash"**, which is the exact `token_reuse` trigger.

Verify the single-instance invariant:
```bash
ls app/node_modules/.pnpm | grep mero-js   # exactly one: @calimero-network+mero-js@6.1.0
```

Manual (desktop SSO): open curb from tauri-app, leave it idle past the access-token lifetime so mero-js rotates, then re-open it from the desktop again. Before this PR the second open wrote the desktop's stale bundle back over the rotated one and the next request 401'd into `token_reuse` → logged out everywhere. After, the rotated bundle survives and the session continues.

## Depends on

- calimero-network/core#3083 (single-use refresh tokens / `token_reuse` semantics)
- calimero-network/mero-js#67 (rotation-safe mero-js: single-flight, cross-tab lock, terminal `AuthRevokedError`)

This PR is the app-side half: it stops curb from *creating* the double-spend. mero-js#67 hardens the SDK path itself. Neither strictly requires the other, but the fix is only complete with both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)