### PR TITLE
chore: bump calimero core deps to 0.11.0-rc.14

### DIFF
--- a/logic/Cargo.lock
+++ b/logic/Cargo.lock
@@ -92,14 +92,14 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "calimero-prelude"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "borsh",
  "calimero-primitives",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "calimero-primitives"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "borsh",
  "bs58",
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "quote",
  "syn",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "calimero-sys"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "cfg-if",
 ]
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "calimero-wasm-abi"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.13#64c17161102cc68c226c5c051315802b95583143"
+source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
 dependencies = [
  "proc-macro2",
  "serde",
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "multiaddr"
@@ -759,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -901,9 +901,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -1146,18 +1146,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1240,6 +1240,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -12,19 +12,19 @@ base64 = "0.22.1"
 borsh = "1.6.1"
 borsh-derive = "1.6.1"
 bs58 = "0.5.1"
-calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
-calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
+calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
+calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13" }
+calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
 serde_json = "1.0.113"
 
 [dev-dependencies]
 # Enables register_crdt_merge + the native mock host so TestHost can drive the
 # AccessControl writer-set state under `cargo test`.
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.13", features = ["testing"] }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14", features = ["testing"] }
 
 [profile.app-release]
 inherits = "release"


### PR DESCRIPTION
Bumps all Calimero core git-tag dependencies in \`logic/Cargo.toml\` from \`0.11.0-rc.13\` to \`0.11.0-rc.14\` (calimero-sdk, calimero-storage, calimero-storage-macros, calimero-wasm-abi, and the testing dev-dependency).

- **cargo update:** succeeded — \`Cargo.lock\` re-resolved all core git deps to the rc.14 tag (\`ec91a0d7\`).
- **WASM build (\`build.sh\`):** compiled cleanly — \`app-release\` finished, \`logic/res/curb.wasm\` rebuilt. (res/ is gitignored, so no wasm is committed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)