### PR TITLE
chore: track core master via branch dependency (currently rc.15+)

### DIFF
--- a/logic/Cargo.lock
+++ b/logic/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 [[package]]
 name = "calimero-prelude"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "borsh",
  "calimero-primitives",
@@ -110,7 +110,7 @@ dependencies = [
 [[package]]
 name = "calimero-primitives"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "borsh",
  "bs58",
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -144,7 +144,7 @@ dependencies = [
 [[package]]
 name = "calimero-sdk-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "borsh",
  "calimero-prelude",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "calimero-storage-macros"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "quote",
  "syn",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "calimero-sys"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "cfg-if",
 ]
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "calimero-wasm-abi"
 version = "0.0.0"
-source = "git+https://github.com/calimero-network/core.git?tag=0.11.0-rc.14#ec91a0d71b93a0fad089d3f58f90a0f16626dcb8"
+source = "git+https://github.com/calimero-network/core.git?branch=master#4ea1a40c55f0894226de392dbd545c1badb1b2e7"
 dependencies = [
  "proc-macro2",
  "serde",

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -12,19 +12,19 @@ base64 = "0.22.1"
 borsh = "1.6.1"
 borsh-derive = "1.6.1"
 bs58 = "0.5.1"
-calimero-sdk = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
-calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
+calimero-sdk = { git = "https://github.com/calimero-network/core.git", branch = "master" }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", branch = "master" }
+calimero-storage-macros = { git = "https://github.com/calimero-network/core.git", branch = "master" }
 thiserror = "1.0.56"
 
 [build-dependencies]
-calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14" }
+calimero-wasm-abi = { git = "https://github.com/calimero-network/core.git", branch = "master" }
 serde_json = "1.0.113"
 
 [dev-dependencies]
 # Enables register_crdt_merge + the native mock host so TestHost can drive the
 # AccessControl writer-set state under `cargo test`.
-calimero-storage = { git = "https://github.com/calimero-network/core.git", tag = "0.11.0-rc.14", features = ["testing"] }
+calimero-storage = { git = "https://github.com/calimero-network/core.git", branch = "master", features = ["testing"] }
 
 [profile.app-release]
 inherits = "release"


### PR DESCRIPTION
Switches the core SDK git deps from a hard-pinned release tag to `branch = "master"` — per Fran: works with app-level Cargo.toml changes only, no core-side machinery.

- Cargo.lock records the exact resolved commit (`4ea1a40c`, master = rc.15 + a few follow-ups), so builds stay reproducible — nothing floats silently.
- Moving forward is `cargo update calimero-…` — no more dependency-line edits on every core release.

Verified: WASM build + contract test suites green against that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)