### PR TITLE
fix(bundle): declare the current frontend URL in the registry manifest

### DIFF
--- a/logic/build-bundle.sh
+++ b/logic/build-bundle.sh
@@ -90,7 +90,7 @@ cat > res/bundle-temp/manifest.json <<EOF
   },
   "migrations": [],
   "links": {
-    "frontend": "https://calimero-curb-rs.vercel.app/"
+    "frontend": "https://mero-chat.vercel.app/"
   }
 }
 EOF


### PR DESCRIPTION
The published bundle declares `https://calimero-curb-rs.vercel.app/` as this app's frontend. Since **auth-frontend v1.3.2**, the SSO token handoff trusts callback origins via the registry-declared `links.frontend` (OAuth registered-redirect-URI style) — so the stale URL makes every login from **https://mero-chat.vercel.app** fail with *"Login callback destination is not allowed"*. All other mero apps' bundles declare their current domains; mero-chat was the only stale one.

On merge, the registry auto-publish ships a new bundle version with the corrected manifest and logins work again — no auth-frontend change needed (the policy did its job: it refused to hand tokens to an origin the registry doesn't vouch for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)