### PR TITLE
chore(deps): bump mero-js →^7.0.2, mero-react →^4.4.1

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@braintree/sanitize-url": "^7.1.1",
-    "@calimero-network/mero-js": "^6.1.0",
-    "@calimero-network/mero-react": "^4.3.4",
+    "@calimero-network/mero-js": "^7.0.2",
+    "@calimero-network/mero-react": "^4.4.1",
     "@calimero-network/mero-ui": "1.4.0",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-dialog": "^1.1.18",

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -16,11 +16,11 @@ importers:
         specifier: ^7.1.1
         version: 7.1.1
       '@calimero-network/mero-js':
-        specifier: ^6.1.0
-        version: 6.1.0
+        specifier: ^7.0.2
+        version: 7.0.2
       '@calimero-network/mero-react':
-        specifier: ^4.3.4
-        version: 4.3.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^4.4.1
+        version: 4.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@calimero-network/mero-ui':
         specifier: 1.4.0
         version: 1.4.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.6.3(@tiptap/pm@3.6.3))(@tiptap/pm@3.6.3)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -724,12 +724,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  '@calimero-network/mero-js@6.1.0':
-    resolution: {integrity: sha512-gYabeP3UfDjmlkHgcVPv9aggFedQDjIhbTbqm54k0CTiEH/1xZEo9yW87av/rxrG7CJg8OXE3VggMluhT6biJg==}
+  '@calimero-network/mero-js@7.0.2':
+    resolution: {integrity: sha512-znm5I5Sdw/2EiMjo+xnnp77JmyR66yB4vPbOqC0ci5kKQQfO4SJWYyBEW+0fcYrhhUKjOdDGAVscyf6LgQcH7A==}
     engines: {node: '>=18.0.0'}
 
-  '@calimero-network/mero-react@4.3.4':
-    resolution: {integrity: sha512-6Cenm8KBo6LvANunWVvEmhppHB2Tb1dKZtHTcdo7biZ1xVdnAUkzl6Q6QaRmInQ8/ObtiwMC85vLqnQdzv471A==}
+  '@calimero-network/mero-react@4.4.1':
+    resolution: {integrity: sha512-1UCXcxrB/WxHu4BcW3ZSekMcpd9j8RjY75TtRNhIjHcgZsBrlVorIBxulwHFcbOth8CiwjrKHJ4yxc8RkvdNDQ==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -5051,11 +5051,11 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  '@calimero-network/mero-js@6.1.0': {}
+  '@calimero-network/mero-js@7.0.2': {}
 
-  '@calimero-network/mero-react@4.3.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@calimero-network/mero-react@4.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@calimero-network/mero-js': 6.1.0
+      '@calimero-network/mero-js': 7.0.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 


### PR DESCRIPTION
Bumps the app's Calimero SDK deps to the rc.17 line:

- `@calimero-network/mero-js`: `^6.1.0` → `^7.0.2`
- `@calimero-network/mero-react`: `^4.3.4` → `^4.4.1` (this release already pins mero-js `^7`)

`pnpm install` + `pnpm build` green locally. Opening for CI/review — not auto-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)