### PR TITLE
ci: fail the publish when the registry records the wrong author

### DIFF
--- a/.github/workflows/deploy-bundle.yml
+++ b/.github/workflows/deploy-bundle.yml
@@ -207,11 +207,16 @@ jobs:
         uses: ./.github/actions/install-cargo-mero
 
       - name: Write signing key
+        id: signkey
         env:
           MERO_SIGN_KEY: ${{ secrets.MERO_SIGN_KEY }}
         run: |
           umask 077
           printf '%s' "$MERO_SIGN_KEY" > "$RUNNER_TEMP/mero-sign-key.json"
+          # Published as an output (the signerId is a public key, not a secret) so
+          # the post-publish check can confirm the registry recorded THIS signer.
+          signer=$(jq -r '.signer_id // ""' "$RUNNER_TEMP/mero-sign-key.json")
+          echo "signer_id=$signer" >> "$GITHUB_OUTPUT"
 
       - name: Verify signer matches the published package
         env:
@@ -296,6 +301,58 @@ jobs:
           CALIMERO_REGISTRY_URL: https://apps.calimero.network
           PACKAGE: ${{ needs.check.outputs.package }}
         run: cargo mero publish "dist/$PACKAGE.mpk"
+
+      # The registry attributes a publish to whatever account owns the API key it
+      # was made with, and stamps `metadata.author` with that account's username —
+      # it does NOT use the `author` field from Cargo.toml. So a personal API key
+      # silently publishes an org app under a personal name, with nothing in the
+      # run log to show it.
+      #
+      # That is exactly what happened here: a repo-level CALIMERO_REGISTRY_API_KEY
+      # shadowed the organization secret (repo secrets win), and this package went
+      # out as author "frand". mero-ar, which has no repo-level secrets and so uses
+      # the org key, published correctly as "calimero-network".
+      #
+      # This step fails the run if the registry did not record the expected
+      # publisher, so the same mistake can never ship quietly again.
+      - name: Verify the registry recorded the expected publisher and signer
+        env:
+          PACKAGE: ${{ needs.check.outputs.package }}
+          VERSION: ${{ needs.check.outputs.version }}
+          EXPECTED_AUTHOR: ${{ vars.EXPECTED_REGISTRY_AUTHOR || 'calimero-network' }}
+          EXPECTED_SIGNER: ${{ steps.signkey.outputs.signer_id }}
+        run: |
+          set -euo pipefail
+          url="https://apps.calimero.network/api/v2/bundles/$PACKAGE/$VERSION"
+          # The publish is not necessarily readable the instant it returns.
+          for attempt in 1 2 3 4 5; do
+            manifest=$(curl -sf "$url") && break
+            echo "manifest not readable yet (attempt $attempt)"
+            sleep 5
+          done
+          if [ -z "${manifest:-}" ]; then
+            echo "::error::published $PACKAGE $VERSION but could not read it back from the registry"
+            exit 1
+          fi
+
+          author=$(printf '%s' "$manifest" | jq -r '.metadata.author // ""')
+          signer=$(printf '%s' "$manifest" | jq -r '.signerId // ""')
+          echo "registry recorded author=$author signerId=$signer"
+
+          if [ "$author" != "$EXPECTED_AUTHOR" ]; then
+            echo "::error::published as \"$author\" but expected \"$EXPECTED_AUTHOR\". The API key used is not the organization's. Remove any repo-level CALIMERO_REGISTRY_API_KEY secret so the organization secret applies (a repo secret shadows an org secret of the same name)."
+            exit 1
+          fi
+
+          # Guards the more dangerous half: the node derives ApplicationId from
+          # (package, signer), so a changed signer silently ships a DIFFERENT app
+          # and orphans every installed instance and invite link.
+          if [ -n "$EXPECTED_SIGNER" ] && [ "$signer" != "$EXPECTED_SIGNER" ]; then
+            echo "::error::registry recorded signer $signer but this run signed with $EXPECTED_SIGNER"
+            exit 1
+          fi
+
+          echo "::notice::$PACKAGE $VERSION published as $author (signer $signer)"
 
       - name: Summary
         env:


### PR DESCRIPTION
This app was published to the App Registry as author **`frand`** instead of `calimero-network`, and nothing in the run log showed it.

## Cause

The registry attributes a publish to **whatever account owns the API key it was made with**, and stamps `metadata.author` with that account's username. It does **not** use the `author` field in `Cargo.toml`.

Proof — all three repos declare `author = "Calimero"`, yet the registry records something else entirely:

| package | registry `metadata.author` | `signerId` |
| --- | --- | --- |
| `com.calimero.mero-ar` | `calimero-network` ✅ | `…z6MkoWkrr…` |
| `com.calimero.chat` | `calimero-network` ✅ | `…z6MkoWkrr…` |
| `com.calimero.meroblocks` | **`frand`** ❌ | `…z6Mkrc…` |
| `com.calimero.curb` | **`frand`** ❌ | `…z6Mkrc…` |

And the reason those two differ:

```
$ gh secret list -R calimero-network/mero-ar
(none — inherits the organization secrets)

$ gh secret list -R calimero-network/mero-chat
CALIMERO_REGISTRY_API_KEY   2026-07-13
MERO_SIGN_KEY               2026-07-16

$ gh secret list -R calimero-network/mero-blocks
CALIMERO_REGISTRY_API_KEY   2026-07-13
MERO_SIGN_KEY               2026-07-16
```

**A repo-level secret shadows an organization secret of the same name.** mero-ar has none, so it uses the org key and publishes correctly. mero-chat and mero-blocks each carry a repo-level `CALIMERO_REGISTRY_API_KEY` — a personal key — which wins.

## The actual fix is a settings change, not this PR

Deleting the repo-level `CALIMERO_REGISTRY_API_KEY` here (so the org secret applies, exactly like mero-ar) is what fixes the attribution. That is a repo-settings action and I have deliberately not done it — see the warning below.

## ⚠️ Do not swap `MERO_SIGN_KEY` at the same time

The repo-level `MERO_SIGN_KEY` also differs from the org one, and that half is dangerous. This workflow's own header says it: the registry pins the signer per package, and **the node derives `ApplicationId` from `(package, signer)`** — so publishing with a different key ships a *different app*. Every installed instance and every invite link for the current app would be orphaned.

So: change **only** the API key, and keep the existing signing key — unless you deliberately want a new `ApplicationId` and are prepared to re-point users.

## What this PR does add

The check that would have caught this. After publishing, it reads the manifest back and fails the run if the registry did not record the expected author:

```
::error::published as "frand" but expected "calimero-network". The API key used is
not the organization's. Remove any repo-level CALIMERO_REGISTRY_API_KEY secret so
the organization secret applies (a repo secret shadows an org secret of the same name).
```

`vars.EXPECTED_REGISTRY_AUTHOR` overrides the `calimero-network` default if a repo should legitimately publish under another account.

It also asserts the recorded `signerId` matches the key the run actually signed with, which turns the ApplicationId hazard above into a hard failure rather than a silent one. The `signerId` is a public key, so exposing it as a step output leaks nothing.

Verified by running the check's script against live registry data: it passes for `com.calimero.mero-ar` and fails for both `com.calimero.meroblocks` and `com.calimero.curb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
